### PR TITLE
Fix for race condition in interface interceptors

### DIFF
--- a/Source/Glass.Mapper/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfacePropertyInterceptor.cs
+++ b/Source/Glass.Mapper/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfacePropertyInterceptor.cs
@@ -13,80 +13,85 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  
-*/ 
+*/
 //-CRE-
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using Castle.DynamicProxy;
 
 namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateInterface
 {
-    /// <summary>
-    /// Class InterfacePropertyInterceptor
-    /// </summary>
-    public class InterfacePropertyInterceptor : IInterceptor
-    {
-        private readonly ObjectConstructionArgs _args;
-        Dictionary<string, object> _values;
-        bool _isLoaded = false;
+	/// <summary>
+	/// Class InterfacePropertyInterceptor
+	/// </summary>
+	public class InterfacePropertyInterceptor : IInterceptor
+	{
+		private readonly ObjectConstructionArgs _args;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InterfacePropertyInterceptor"/> class.
-        /// </summary>
-        /// <param name="args">The args.</param>
-        public InterfacePropertyInterceptor(ObjectConstructionArgs args)
-        {
-            _args = args;
-        }
+		private readonly Lazy<IDictionary<string, object>> _lazyValues;
 
-        /// <summary>
-        /// Intercepts the specified invocation.
-        /// </summary>
-        /// <param name="invocation">The invocation.</param>
-        /// <exception cref="Glass.Mapper.MapperException">Method with name {0}{1} on type {2} not supported..Formatted(method, name, _args.Configuration.Type.FullName)</exception>
-        public void Intercept(IInvocation invocation)
-        {
-            var config = _args.Configuration;
+		protected IDictionary<string, object> Values { get { return _lazyValues.Value; } }
 
-            //do initial gets
-            if (!_isLoaded)
-            {
-                _values = new Dictionary<string, object>();
-                var mappingContext = _args.Service.CreateDataMappingContext(_args.AbstractTypeCreationContext, null);
+		/// <summary>
+		/// Initializes a new instance of the <see cref="InterfacePropertyInterceptor"/> class.
+		/// </summary>
+		/// <param name="args">The args.</param>
+		public InterfacePropertyInterceptor(ObjectConstructionArgs args)
+		{
+			_args = args;
+			_lazyValues = new Lazy<IDictionary<string, object>>(LoadValues);
+		}
 
-                foreach (var property in config.Properties)
-                {
-                    var result = property.Mapper.MapToProperty(mappingContext);
-                    _values[property.PropertyInfo.Name] = result;
-                }
-                _isLoaded = true;
-            }
+		/// <summary>
+		/// Intercepts the specified invocation.
+		/// </summary>
+		/// <param name="invocation">The invocation.</param>
+		/// <exception cref="Glass.Mapper.MapperException">Method with name {0}{1} on type {2} not supported..Formatted(method, name, _args.Configuration.Type.FullName)</exception>
+		public void Intercept(IInvocation invocation)
+		{
+			var config = _args.Configuration;
 
-            if (invocation.Method.IsSpecialName)
-            {
-                if (invocation.Method.Name.StartsWith("get_") || invocation.Method.Name.StartsWith("set_"))
-                {
+			if (invocation.Method.IsSpecialName)
+			{
+				if (invocation.Method.Name.StartsWith("get_") || invocation.Method.Name.StartsWith("set_"))
+				{
 
-                    string method = invocation.Method.Name.Substring(0, 4);
-                    string name = invocation.Method.Name.Substring(4);
+					string method = invocation.Method.Name.Substring(0, 4);
+					string name = invocation.Method.Name.Substring(4);
 
-                    if (method == "get_")
-                    {
-                        var result = _values[name];
-                        invocation.ReturnValue = result;
-                    }
-                    else if (method == "set_")
-                    {
-                        _values[name] = invocation.Arguments[0];
-                    }
-                    else
-                        throw new MapperException("Method with name {0}{1} on type {2} not supported.".Formatted(
-                            method, name, config.Type.FullName));
-                }
-            }
-        }
-    }
+					if (method == "get_")
+					{
+						var result = Values[name];
+						invocation.ReturnValue = result;
+					}
+					else if (method == "set_")
+					{
+						Values[name] = invocation.Arguments[0];
+					}
+					else
+						throw new MapperException("Method with name {0}{1} on type {2} not supported.".Formatted(
+							method, name, config.Type.FullName));
+				}
+			}
+		}
+
+		private IDictionary<string, object> LoadValues()
+		{
+			var config = _args.Configuration;
+
+			var values = new Dictionary<string, object>();
+			var mappingContext = _args.Service.CreateDataMappingContext(_args.AbstractTypeCreationContext, null);
+
+			foreach (var property in config.Properties)
+			{
+				var result = property.Mapper.MapToProperty(mappingContext);
+				values[property.PropertyInfo.Name] = result;
+			}
+
+			return values;
+		}
+	}
 }
 
 

--- a/Source/Glass.Mapper/Pipelines/ObjectConstruction/Tasks/CreateMultiInterface/MultiInterfacePropertyInterceptor.cs
+++ b/Source/Glass.Mapper/Pipelines/ObjectConstruction/Tasks/CreateMultiInterface/MultiInterfacePropertyInterceptor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Castle.DynamicProxy;
 using Glass.Mapper.Configuration;
@@ -8,8 +9,9 @@ namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateMultiInterface
     public class MultiInterfacePropertyInterceptor : IInterceptor
     {
         private readonly ObjectConstructionArgs _args;
-        Dictionary<string, object> _values;
-        bool _isLoaded = false;
+		private readonly Lazy<IDictionary<string, object>> _lazyValues;
+
+		protected IDictionary<string, object> Values { get { return _lazyValues.Value; } }
         private IEnumerable<AbstractTypeConfiguration> _configs;
  
           /// <summary>
@@ -21,29 +23,11 @@ namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateMultiInterface
             _args = args;
               _configs =
                   new[] {args.Configuration}.Union(args.Parameters[CreateMultiInferaceTask.MultiInterfaceConfigsKey] as IEnumerable<AbstractTypeConfiguration>);
+			  _lazyValues = new Lazy<IDictionary<string, object>>(LoadValues);
         }
 
-        public void Intercept(IInvocation invocation)
+	    public void Intercept(IInvocation invocation)
         {
-            
-
-            //do initial gets
-            if (!_isLoaded)
-            {
-                _values = new Dictionary<string, object>();
-                var mappingContext = _args.Service.CreateDataMappingContext(_args.AbstractTypeCreationContext, null);
-
-                foreach (var config in _configs)
-                {
-                    foreach (var property in config.Properties)
-                    {
-                        var result = property.Mapper.MapToProperty(mappingContext);
-                        _values[property.PropertyInfo.Name] = result;
-                    }
-                    _isLoaded = true;
-                }
-            }
-
             if (invocation.Method.IsSpecialName)
             {
                 if (invocation.Method.Name.StartsWith("get_") || invocation.Method.Name.StartsWith("set_"))
@@ -54,12 +38,12 @@ namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateMultiInterface
 
                     if (method == "get_")
                     {
-                        var result = _values[name];
+                        var result = Values[name];
                         invocation.ReturnValue = result;
                     }
                     else if (method == "set_")
                     {
-                        _values[name] = invocation.Arguments[0];
+						Values[name] = invocation.Arguments[0];
                     }
                     else
                         throw new MapperException("Method with name {0}{1} on types {2} not supported.".Formatted(
@@ -68,5 +52,22 @@ namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateMultiInterface
             }
 
         }
+
+		private IDictionary<string, object> LoadValues()
+		{
+			var values = new Dictionary<string, object>();
+			var mappingContext = _args.Service.CreateDataMappingContext(_args.AbstractTypeCreationContext, null);
+
+			foreach (var config in _configs)
+			{
+				foreach (var property in config.Properties)
+				{
+					var result = property.Mapper.MapToProperty(mappingContext);
+					values[property.PropertyInfo.Name] = result;
+				}
+			}
+
+			return values;
+		}
     }
 }


### PR DESCRIPTION
Hi Mike,

I ran into an issue where the interface property interceptor classes were throwing errors due to a race condition during the setup of their respective 'value' dictionaries - we were hoping to be able to cache certain items for re-use across multiple page loads like you would regular Sitecore items.

Hopefully this fix will address that issue, but I would be interested to know your stance on the cachability (and thread-safety) of Glass items.

Thanks,
Chris
