### PR TITLE
GlassTemplatePage and GlassViewPage classes to use new UmbracoPublishedService.

### DIFF
--- a/Source/Glass.Mapper.Umb/DataMappers/UmbracoChildrenMapper.cs
+++ b/Source/Glass.Mapper.Umb/DataMappers/UmbracoChildrenMapper.cs
@@ -57,8 +57,17 @@ namespace Glass.Mapper.Umb.DataMappers
             var umbConfig = Configuration as UmbracoChildrenConfiguration;
 
             Type genericType = Utilities.GetGenericArgument(Configuration.PropertyInfo.PropertyType);
-            
-            Func<IEnumerable<IContent>> getItems = () => umbContext.Service.ContentService.GetChildren(umbContext.Content.Id).Select(c => umbContext.Service.ContentService.GetPublishedVersion(c.Id));
+
+            Func<IEnumerable<IContent>> getItems = null;
+            if (umbContext.PublishedOnly)
+            {
+                getItems = () => umbContext.Service.ContentService.GetChildren(umbContext.Content.Id)
+                                     .Select(c => umbContext.Service.ContentService.GetPublishedVersion(c.Id));
+            }
+            else
+            {
+                getItems = () => umbContext.Service.ContentService.GetChildren(umbContext.Content.Id);
+            }
 
             return Utilities.CreateGenericType(
                 typeof(LazyContentEnumerable<>),

--- a/Source/Glass.Mapper.Umb/DataMappers/UmbracoParentMapper.cs
+++ b/Source/Glass.Mapper.Umb/DataMappers/UmbracoParentMapper.cs
@@ -17,6 +17,7 @@
 //-CRE-
 using System;
 using Glass.Mapper.Umb.Configuration;
+using Umbraco.Core.Models;
 
 namespace Glass.Mapper.Umb.DataMappers
 {
@@ -53,9 +54,15 @@ namespace Glass.Mapper.Umb.DataMappers
             var umbContext = mappingContext as UmbracoDataMappingContext;
             var umbConfig = Configuration as UmbracoParentConfiguration;
 
+            IContent content = umbContext.PublishedOnly
+                                   ? umbContext.Service.ContentService.GetPublishedVersion(umbContext.Content.ParentId)
+                                   : umbContext.Service.ContentService.GetById(umbContext.Content.ParentId);
+
+
+
             return umbContext.Service.CreateType(
                 umbConfig.PropertyInfo.PropertyType,
-                umbContext.Service.ContentService.GetPublishedVersion(umbContext.Content.ParentId),
+                content,
                 umbConfig.IsLazy,
                 umbConfig.InferType);
         }

--- a/Source/Glass.Mapper.Umb/DataMappers/UmbracoPropertyTypeMapper.cs
+++ b/Source/Glass.Mapper.Umb/DataMappers/UmbracoPropertyTypeMapper.cs
@@ -41,7 +41,10 @@ namespace Glass.Mapper.Umb.DataMappers
             if (!int.TryParse(propertyValue.ToString(), out id))
                 return null;
 
-            var item = context.Service.ContentService.GetPublishedVersion(id);
+            var item = context.PublishedOnly
+                           ? context.Service.ContentService.GetPublishedVersion(id)
+                           : context.Service.ContentService.GetById(id);
+
             return context.Service.CreateType(config.PropertyInfo.PropertyType, item, IsLazy, InferType);
         }
 

--- a/Source/Glass.Mapper.Umb/Glass.Mapper.Umb.csproj
+++ b/Source/Glass.Mapper.Umb/Glass.Mapper.Umb.csproj
@@ -64,10 +64,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU' Or  '$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'Net45|AnyCPU' ">
-
   </ItemGroup>
   <ItemGroup>
     <Reference Include="AutoMapper">
@@ -289,6 +287,7 @@
     <Compile Include="LazyContentEnumerable.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UmbracoContext.cs" />
+    <Compile Include="UmbracoPublishedService.cs" />
     <Compile Include="UmbracoTypeSavingContext.cs" />
     <Compile Include="UmbracoTypeCreationContext.cs" />
     <Compile Include="UmbracoService.cs" />

--- a/Source/Glass.Mapper.Umb/UmbracoDataMappingContext.cs
+++ b/Source/Glass.Mapper.Umb/UmbracoDataMappingContext.cs
@@ -30,11 +30,12 @@ namespace Glass.Mapper.Umb
         /// <param name="obj">The obj.</param>
         /// <param name="content">The content.</param>
         /// <param name="service">The service.</param>
-        public UmbracoDataMappingContext(object obj, IContent content, IUmbracoService service)
+        public UmbracoDataMappingContext(object obj, IContent content, IUmbracoService service, bool publishedOnly)
             : base(obj)
         {
             Content = content;
             Service = service;
+            PublishedOnly = publishedOnly;
         }
 
         /// <summary>
@@ -52,6 +53,9 @@ namespace Glass.Mapper.Umb
         /// The service.
         /// </value>
         public IUmbracoService Service { get; set; }
+
+
+        public bool PublishedOnly { get; set; }
     }
 }
 

--- a/Source/Glass.Mapper.Umb/UmbracoPublishedService.cs
+++ b/Source/Glass.Mapper.Umb/UmbracoPublishedService.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Services;
+
+namespace Glass.Mapper.Umb
+{
+    public class UmbracoPublishedService : UmbracoService
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoService"/> class.
+        /// </summary>
+        /// <param name="contentService">The content service.</param>
+        /// <param name="contextName">Name of the context.</param>
+        public UmbracoPublishedService(IContentService contentService, string contextName = "Default")
+            :base(contentService, contextName)
+        {
+            this.PublishedOnly = true;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoService"/> class.
+        /// </summary>
+        /// <param name="contentService">The content service.</param>
+        /// <param name="context">The context.</param>
+        public UmbracoPublishedService(IContentService contentService, Context context)
+            : base(contentService, context)
+        {
+            this.PublishedOnly = true;
+        }
+    }
+}

--- a/Source/Glass.Mapper.Umb/UmbracoService.cs
+++ b/Source/Glass.Mapper.Umb/UmbracoService.cs
@@ -37,6 +37,8 @@ namespace Glass.Mapper.Umb
         /// </value>
         public IContentService ContentService { get; private set; }
 
+        public bool PublishedOnly { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoService"/> class.
         /// </summary>
@@ -86,7 +88,10 @@ namespace Glass.Mapper.Umb
             {
                 return null;
             }
-            var item = ContentService.GetPublishedVersion(id.Value);
+            var item = PublishedOnly
+                           ? ContentService.GetPublishedVersion(id.Value)
+                           : ContentService.GetById(id.Value);
+
             return CreateType(typeof(T), item, isLazy, inferType) as T;
         }
 
@@ -101,6 +106,10 @@ namespace Glass.Mapper.Umb
         public T GetItem<T>(Guid id, bool isLazy = false, bool inferType = false) where T : class
         {
             var item = ContentService.GetById(id);
+
+            if (PublishedOnly)
+                item = ContentService.GetPublishedVersion(item.Id);
+
             return CreateType(typeof(T), item, isLazy, inferType) as T;
         }
 
@@ -154,7 +163,8 @@ namespace Glass.Mapper.Umb
                     ConstructorParameters = constructorParameters,
                     Content = content,
                     InferType = inferType,
-                    IsLazy = isLazy
+                    IsLazy = isLazy,
+                    PublishedOnly =  PublishedOnly
                 };
             var obj = InstantiateObject(creationContext);
 
@@ -393,7 +403,7 @@ namespace Glass.Mapper.Umb
         public override AbstractDataMappingContext CreateDataMappingContext(AbstractTypeCreationContext abstractTypeCreationContext, Object obj)
         {
             var umbTypeContext = abstractTypeCreationContext as UmbracoTypeCreationContext;
-            return new UmbracoDataMappingContext(obj, umbTypeContext.Content, this);
+            return new UmbracoDataMappingContext(obj, umbTypeContext.Content, this, umbTypeContext.PublishedOnly);
         }
 
         /// <summary>
@@ -404,7 +414,7 @@ namespace Glass.Mapper.Umb
         public override AbstractDataMappingContext CreateDataMappingContext(AbstractTypeSavingContext creationContext)
         {
             var umbContext = creationContext as UmbracoTypeSavingContext;
-            return new UmbracoDataMappingContext(umbContext.Object, umbContext.Content, this);
+            return new UmbracoDataMappingContext(umbContext.Object, umbContext.Content, this, umbContext.PublishedOnly);
         }
     }
 }

--- a/Source/Glass.Mapper.Umb/UmbracoTypeCreationContext.cs
+++ b/Source/Glass.Mapper.Umb/UmbracoTypeCreationContext.cs
@@ -44,6 +44,8 @@ namespace Glass.Mapper.Umb
         /// The umbraco service.
         /// </value>
         public IUmbracoService UmbracoService { get; set; }
+
+        public bool PublishedOnly { get; set; }
     }
 }
 

--- a/Source/Glass.Mapper.Umb/UmbracoTypeSavingContext.cs
+++ b/Source/Glass.Mapper.Umb/UmbracoTypeSavingContext.cs
@@ -35,6 +35,8 @@ namespace Glass.Mapper.Umb
         /// The content.
         /// </value>
         public IContent Content { get; set; }
+
+        public bool PublishedOnly { get; set; }
     }
 }
 

--- a/Tests/Integration Tests/Umbraco/Glass.Mapper.Umb.Integration/DataMappers/AbstractUmbracoPropertyMapperFixture.cs
+++ b/Tests/Integration Tests/Umbraco/Glass.Mapper.Umb.Integration/DataMappers/AbstractUmbracoPropertyMapperFixture.cs
@@ -144,7 +144,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             mapper.Setup(new DataMapperResolverArgs(null,config));
             mapper.Value = propertyValue;
 
-            var context = new UmbracoDataMappingContext(null, content, null);
+            var context = new UmbracoDataMappingContext(null, content, null, false);
 
             content.Properties[propertyAlias].Value = propertyValue;
 
@@ -175,7 +175,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             mapper.Setup(new DataMapperResolverArgs(null, config));
             mapper.Value = propertyValue;
 
-            var context = new UmbracoDataMappingContext(new Stub(), content, null);
+            var context = new UmbracoDataMappingContext(new Stub(), content, null, false);
 
             content.Properties[propertyAlias].Value = string.Empty;
 

--- a/Tests/Integration Tests/Umbraco/Glass.Mapper.Umb.Integration/DataMappers/UmbracoChildrenMapperFixture.cs
+++ b/Tests/Integration Tests/Umbraco/Glass.Mapper.Umb.Integration/DataMappers/UmbracoChildrenMapperFixture.cs
@@ -62,7 +62,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
                                                                                       Id =  info.Arg<IContent>().Id
                                                                                   });
 
-            var context = new UmbracoDataMappingContext(null, content, service);
+            var context = new UmbracoDataMappingContext(null, content, service, false);
             mapper.Setup(new DataMapperResolverArgs(null, config));
 
             //Act
@@ -100,7 +100,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
                 Id = info.Arg<IContent>().Id
             });
 
-            var context = new UmbracoDataMappingContext(null, content, service);
+            var context = new UmbracoDataMappingContext(null, content, service, false);
             mapper.Setup(new DataMapperResolverArgs(null, config));
 
             //Act

--- a/Tests/Integration Tests/Umbraco/Glass.Mapper.Umb.Integration/DataMappers/UmbracoIdMapperFixture.cs
+++ b/Tests/Integration Tests/Umbraco/Glass.Mapper.Umb.Integration/DataMappers/UmbracoIdMapperFixture.cs
@@ -69,7 +69,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             
             mapper.Setup(new DataMapperResolverArgs(null, config));
 
-            var dataContext = new UmbracoDataMappingContext(null, content, null);
+            var dataContext = new UmbracoDataMappingContext(null, content, null, false);
             var expected = content.Id;
 
             //Act
@@ -95,7 +95,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
 
             mapper.Setup(new DataMapperResolverArgs(null, config));
 
-            var dataContext = new UmbracoDataMappingContext(null, content, null);
+            var dataContext = new UmbracoDataMappingContext(null, content, null, false);
             var expected = content.Key;
 
             //Act

--- a/Tests/Integration Tests/Umbraco/Glass.Mapper.Umb.Integration/DataMappers/UmbracoInfoMapperFixture.cs
+++ b/Tests/Integration Tests/Umbraco/Glass.Mapper.Umb.Integration/DataMappers/UmbracoInfoMapperFixture.cs
@@ -67,7 +67,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             var content = contentService.GetById(new Guid("{FB6A8073-48B4-4B85-B80C-09CBDECC27C9}"));
 
             Assert.IsNotNull(content, "Content is null, check in Umbraco that item exists");
-            var dataContext = new UmbracoDataMappingContext(null, content, null);
+            var dataContext = new UmbracoDataMappingContext(null, content, null, false);
 
             //Act
             var value = mapper.MapToProperty(dataContext);
@@ -93,7 +93,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             var content = contentService.GetById(new Guid("{FB6A8073-48B4-4B85-B80C-09CBDECC27C9}"));
 
             Assert.IsNotNull(content, "Content is null, check in Umbraco that item exists");
-            var dataContext = new UmbracoDataMappingContext(null, content, null);
+            var dataContext = new UmbracoDataMappingContext(null, content, null, false);
 
             //Act
             var value = mapper.MapToProperty(dataContext);
@@ -118,7 +118,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             var expected = content.Version;
 
             Assert.IsNotNull(content, "Content is null, check in Umbraco that item exists");
-            var dataContext = new UmbracoDataMappingContext(null, content, null);
+            var dataContext = new UmbracoDataMappingContext(null, content, null, false);
 
             //Act
             var value = mapper.MapToProperty(dataContext);
@@ -143,7 +143,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             var expected = content.Path;
 
             Assert.IsNotNull(content, "Content is null, check in Umbraco that item exists");
-            var dataContext = new UmbracoDataMappingContext(null, content, null);
+            var dataContext = new UmbracoDataMappingContext(null, content, null, false);
 
             //Act
             var value = mapper.MapToProperty(dataContext);
@@ -168,7 +168,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             var expected = content.CreateDate;
 
             Assert.IsNotNull(content, "Content is null, check in Umbraco that item exists");
-            var dataContext = new UmbracoDataMappingContext(null, content, null);
+            var dataContext = new UmbracoDataMappingContext(null, content, null, false);
 
             //Act
             var value = mapper.MapToProperty(dataContext);
@@ -193,7 +193,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             var expected = content.UpdateDate;
 
             Assert.IsNotNull(content, "Content is null, check in Umbraco that item exists");
-            var dataContext = new UmbracoDataMappingContext(null, content, null);
+            var dataContext = new UmbracoDataMappingContext(null, content, null, false);
 
             //Act
             var value = mapper.MapToProperty(dataContext);
@@ -225,7 +225,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             Assert.IsNotNull(content, "Content is null, check in Umbraco that item exists");
 
             var context = Context.Create(DependencyResolver.CreateStandardResolver());
-            var dataContext = new UmbracoDataMappingContext(null, content, new UmbracoService(contentService, context));
+            var dataContext = new UmbracoDataMappingContext(null, content, new UmbracoService(contentService, context), false);
             dataContext.PropertyValue = expected;
 
             string actual = string.Empty;

--- a/Tests/Integration Tests/Umbraco/Glass.Mapper.Umb.Integration/DataMappers/UmbracoParentMapperFixture.cs
+++ b/Tests/Integration Tests/Umbraco/Glass.Mapper.Umb.Integration/DataMappers/UmbracoParentMapperFixture.cs
@@ -63,7 +63,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             var content = contentService.GetById(new Guid("{C382AE57-D325-4357-A32A-0A959BBD4101}"));
             var service = Substitute.For<IUmbracoService>();
             service.ContentService.Returns(contentService);
-            var context = new UmbracoDataMappingContext(null, content, service);
+            var context = new UmbracoDataMappingContext(null, content, service, false);
 
             var config = new UmbracoParentConfiguration();
             config.PropertyInfo = typeof(Stub).GetProperty("Property");
@@ -87,7 +87,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             var content = contentService.GetById(new Guid("{C382AE57-D325-4357-A32A-0A959BBD4101}"));
             var service = Substitute.For<IUmbracoService>();
             service.ContentService.Returns(contentService);
-            var context = new UmbracoDataMappingContext(null, content, service);
+            var context = new UmbracoDataMappingContext(null, content, service, false);
 
             var config = new UmbracoParentConfiguration();
             config.PropertyInfo = typeof(Stub).GetProperty("Property");
@@ -112,7 +112,7 @@ namespace Glass.Mapper.Umb.Integration.DataMappers
             var content = contentService.GetById(new Guid("{C382AE57-D325-4357-A32A-0A959BBD4101}"));
             var service = Substitute.For<IUmbracoService>();
             service.ContentService.Returns(contentService);
-            var context = new UmbracoDataMappingContext(null, content, service);
+            var context = new UmbracoDataMappingContext(null, content, service, false);
 
             var config = new UmbracoParentConfiguration();
             config.PropertyInfo = typeof(Stub).GetProperty("Property");


### PR DESCRIPTION
The GlassTemplatePage and GlassViewPage classes in the Glass.Mapper.Umb.Web.Ui namespace need to be modified to use the new UmbracoPublishedService in their constructors.

In this way, you're guaranteed to be getting the published version of the content in your Umbraco MVC views.
