### PR TITLE
SitecoreService.cs - Begin/EndEdit is called twice.

### DIFF
--- a/Source/Glass.Mapper.Sc/SitecoreService.cs
+++ b/Source/Glass.Mapper.Sc/SitecoreService.cs
@@ -245,9 +245,7 @@ namespace Glass.Mapper.Sc
 
             //write new data to the item
 
-            item.Editing.BeginEdit();
             WriteToItem(newItem, item, updateStatistics, silent);
-            item.Editing.EndEdit(updateStatistics, silent);
 
             //then read it back
 


### PR DESCRIPTION
Begin/EndEdit is called twice. Once in Create<T, K> and once inside WriteToItem. We sometimes (!?) get exception "Exception: Sitecore.Exceptions.EditingNotAllowedException Message: Item 'XX' is not in editing mode." when second EndEdit is called after returning from WriteToItem.

Implementation of sitecore Begin/EndEdit does no look like it is meant to be called in such nested way (there is no counter for nested calls, first EndEdit ends editing mode). However it is very strange that mostly it works, we didn't figure out what is different when it throws this exception. But once it throws it, it throws it consistently.
