### PR TITLE
Make the properties of the Image and File property types virtual.

### DIFF
--- a/Source/Glass.Mapper.Umb/PropertyTypes/File.cs
+++ b/Source/Glass.Mapper.Umb/PropertyTypes/File.cs
@@ -30,13 +30,13 @@ namespace Glass.Mapper.Umb.PropertyTypes
         /// Gets the SRC.
         /// </summary>
         /// <value>The SRC.</value>
-        public string Src { get; internal set; }
+        public virtual string Src { get; internal set; }
 
         /// <summary>
         /// Gets or sets the id.
         /// </summary>
         /// <value>The id.</value>
-        public int Id { get; set; }
+        public virtual int Id { get; set; }
 
         /// <summary>
         /// Gets or sets the name.
@@ -44,7 +44,7 @@ namespace Glass.Mapper.Umb.PropertyTypes
         /// <value>
         /// The name.
         /// </value>
-        public string Name { get; set; }
+        public virtual string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the extension.
@@ -52,7 +52,7 @@ namespace Glass.Mapper.Umb.PropertyTypes
         /// <value>
         /// The extension.
         /// </value>
-        public string Extension { get; set; }
+        public virtual string Extension { get; set; }
 
         /// <summary>
         /// Gets or sets the size.
@@ -60,7 +60,7 @@ namespace Glass.Mapper.Umb.PropertyTypes
         /// <value>
         /// The size.
         /// </value>
-        public int Size { get; set; }
+        public virtual int Size { get; set; }
     }
 }
 

--- a/Source/Glass.Mapper.Umb/PropertyTypes/Image.cs
+++ b/Source/Glass.Mapper.Umb/PropertyTypes/Image.cs
@@ -30,36 +30,36 @@ namespace Glass.Mapper.Umb.PropertyTypes
         /// Gets or sets the alt.
         /// </summary>
         /// <value>The alt.</value>
-        public string Alt { get; set; }
+        public virtual string Alt { get; set; }
         /// <summary>
         /// Gets or sets the extension.
         /// </summary>
         /// <value>
         /// The extension.
         /// </value>
-        public string Extension { get; set; }
+        public virtual string Extension { get; set; }
         /// <summary>
         /// Gets or sets the height.
         /// </summary>
         /// <value>The height.</value>
-        public int Height { get; set; }
+        public virtual int Height { get; set; }
         /// <summary>
         /// Gets the SRC.
         /// </summary>
         /// <value>The SRC.</value>
-        public string Src { get; internal set; }
+        public virtual string Src { get; internal set; }
         /// <summary>
         /// Gets or sets the width.
         /// </summary>
         /// <value>The width.</value>
-        public int Width { get; set; }
+        public virtual int Width { get; set; }
         /// <summary>
         /// Gets or sets the id.
         /// </summary>
         /// <value>
         /// The id.
         /// </value>
-        public int Id { get; set; }
+        public virtual int Id { get; set; }
 
         /// <summary>
         /// Gets or sets the size.
@@ -67,6 +67,6 @@ namespace Glass.Mapper.Umb.PropertyTypes
         /// <value>
         /// The size.
         /// </value>
-        public int Size { get; set; }
+        public virtual int Size { get; set; }
     }
 }


### PR DESCRIPTION
Make the properties of the Image and File property types virtual. This allows the use of mocking frameworks when doing unit testing.

Currently am unable to create a stub or mock object using these classes as there is no way to overwrite the property getters. Also, because the "set" on the Src property is "internal", it is impossible to set the Src property when this object is participating in unit tests.

It might be easier to just make the Src property read/write (for my purposes), but I feel this allows for greater flexibility.

Thanks,

Dan.
