### PR TITLE
Addition of new property to the UmbracoChildren attribute

### DIFF
--- a/Source/Glass.Mapper.Umb/Configuration/Attributes/UmbracoChildrenAttribute.cs
+++ b/Source/Glass.Mapper.Umb/Configuration/Attributes/UmbracoChildrenAttribute.cs
@@ -35,10 +35,15 @@ namespace Glass.Mapper.Umb.Configuration.Attributes
         /// <returns></returns>
         public override AbstractPropertyConfiguration Configure(PropertyInfo propertyInfo)
         {
-            var config = new UmbracoChildrenConfiguration();
+            var config = new UmbracoChildrenConfiguration {DocumentTypeAlias = DocumentTypeAlias};
             base.Configure(propertyInfo, config);
             return config;
         }
+
+        /// <summary>
+        /// Indicates which Document Type this property should map to
+        /// </summary>
+        public virtual string DocumentTypeAlias { get; set; }
     }
 }
 

--- a/Source/Glass.Mapper.Umb/Configuration/UmbracoChildrenConfiguration.cs
+++ b/Source/Glass.Mapper.Umb/Configuration/UmbracoChildrenConfiguration.cs
@@ -26,6 +26,10 @@ namespace Glass.Mapper.Umb.Configuration
     /// </summary>
     public class UmbracoChildrenConfiguration : ChildrenConfiguration
     {
+        /// <summary>
+        /// Which Document Type this property should map to
+        /// </summary>
+        public virtual string DocumentTypeAlias { get; set; }
     }
 }
 

--- a/Source/Glass.Mapper.Umb/DataMappers/UmbracoChildrenMapper.cs
+++ b/Source/Glass.Mapper.Umb/DataMappers/UmbracoChildrenMapper.cs
@@ -61,12 +61,28 @@ namespace Glass.Mapper.Umb.DataMappers
             Func<IEnumerable<IContent>> getItems = null;
             if (umbContext.PublishedOnly)
             {
-                getItems = () => umbContext.Service.ContentService.GetChildren(umbContext.Content.Id)
+                if (String.IsNullOrWhiteSpace(umbConfig.DocumentTypeAlias))
+                {
+                    getItems = () => umbContext.Service.ContentService.GetChildren(umbContext.Content.Id)
                                      .Select(c => umbContext.Service.ContentService.GetPublishedVersion(c.Id));
+                }
+                else
+                {
+                    getItems = () => umbContext.Service.ContentService.GetChildren(umbContext.Content.Id)
+                        .Where(c => c.ContentType.Alias == umbConfig.DocumentTypeAlias)
+                        .Select(c => umbContext.Service.ContentService.GetPublishedVersion(c.Id));
+                }
             }
             else
             {
-                getItems = () => umbContext.Service.ContentService.GetChildren(umbContext.Content.Id);
+                if (String.IsNullOrWhiteSpace(umbConfig.DocumentTypeAlias))
+                {
+                    getItems = () => umbContext.Service.ContentService.GetChildren(umbContext.Content.Id);
+                }
+                else
+                {
+                    getItems = () => umbContext.Service.ContentService.GetChildren(umbContext.Content.Id).Where(c => c.ContentType.Alias == umbConfig.DocumentTypeAlias);
+                }
             }
 
             return Utilities.CreateGenericType(


### PR DESCRIPTION
Addition of new property to the UmbracoChildren attribute to allow mapping of different node types as children.

When you have different types of nodes as children in Umbraco, the mapper needs to know which document type the collection maps to.

I have added a new property to the attribute - DocumentTypeAlias - which allows the property to determine which type it maps to. This allows filtering of the nodes when fetched from the CMS. An exception is thrown otherwise, because all child nodes are added to the collection, regardless of the type.

There may be a cleaner way to achieve this, by avoiding all the nasty if-then nesting.

Thanks,

Dan.
