### PR TITLE
Fixing BeginRenderLink to respect parameters

### DIFF
--- a/Source/Glass.Mapper.Sc/GlassHtml.cs
+++ b/Source/Glass.Mapper.Sc/GlassHtml.cs
@@ -258,6 +258,12 @@ namespace Glass.Mapper.Sc
 
             if (IsInEditingMode && isEditable)
             {
+
+                if (attrs != null)
+                {
+                    attrs.Add("haschildren", "true");
+                    return MakeEditable(field, null, model, attrs, _context, SitecoreContext.Database, writer);
+                }
                 return MakeEditable(field, null, model, "haschildren=true", _context, SitecoreContext.Database, writer);
             }
             else


### PR DESCRIPTION
Similar problem as [Issue #51](https://github.com/mikeedwards83/Glass.Mapper/issues/51), but for BeginRenderLink's Parameters collection.
