### PR TITLE
Fix the issue with the LazyItemEnumerable where IsLazy=False remains laz..

### DIFF
--- a/Source/Glass.Mapper.Sc.Mvc/Glass.Mapper.Sc.Mvc.csproj
+++ b/Source/Glass.Mapper.Sc.Mvc/Glass.Mapper.Sc.Mvc.csproj
@@ -70,7 +70,7 @@
       <HintPath>..\..\Depends\System.Web.WebPages\v2\System.Web.WebPages.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Kernel">
-      <HintPath>..\..\Depends\Sitecore\bin7\Sitecore.Kernel.dll</HintPath>
+      <HintPath>..\..\Depends\Sitecore\bin\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Mvc">
       <HintPath>..\..\Depends\Sitecore\bin7\Sitecore.Mvc.dll</HintPath>

--- a/Source/Glass.Mapper.Sc/LazyItemEnumerable.cs
+++ b/Source/Glass.Mapper.Sc/LazyItemEnumerable.cs
@@ -59,6 +59,12 @@ namespace Glass.Mapper.Sc
             _service = service;
             
             _lazyItemList = new Lazy<IList<T>>(() =>ProcessItems().ToList());
+            
+            if (isLazy == false)
+            {
+                // Force the loading of the items into the list so this occurs in the current security scope.
+                var dummy = _lazyItemList.Value;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Hi Mike,

can you pull this fix into the main branch? This fixes the reported issue https://github.com/mikeedwards83/Glass.Mapper/issues/79

Fix the issue with the LazyItemEnumerable where IsLazy=False remains lazy. Items that are decorated with the SitecoreChildren or SitecoreQuery - Attribute classes with the option to disable the lazy loading is fixed by this.

A side effect of the lazy behavior was that the child items where retrieved in an other UserContext (security scope) than the one where the root object was created in.
