### PR TITLE
Remove GlassMapperException from Number DataMappers

### DIFF
--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldDoubleMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldDoubleMapper.cs
@@ -54,9 +54,13 @@ namespace Glass.Mapper.Sc.DataMappers
         {
             if (fieldValue.IsNullOrEmpty()) return DefaultValue;
             double dValue = (double)DefaultValue;
-            double.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue);
 
-            return dValue;
+            if (double.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue))
+            {
+                return dValue;
+            }
+
+            return double.MinValue;
         }
 
         /// <summary>

--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldDoubleMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldDoubleMapper.cs
@@ -49,14 +49,14 @@ namespace Glass.Mapper.Sc.DataMappers
         /// <param name="config">The config.</param>
         /// <param name="context">The context.</param>
         /// <returns>System.Object.</returns>
-        /// <exception cref="Glass.Mapper.MapperException">Could not convert value to double</exception>
         public override object GetFieldValue(string fieldValue, SitecoreFieldConfiguration config,
                                              SitecoreDataMappingContext context)
         {
-            if (fieldValue.IsNullOrEmpty()) return 0d;
-            double dValue = 0;
-            if (double.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue)) return dValue;
-            else throw new MapperException("Could not convert value to double");
+            if (fieldValue.IsNullOrEmpty()) return DefaultValue;
+            double dValue = (double)DefaultValue;
+            double.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue);
+
+            return dValue;
         }
 
         /// <summary>

--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldIntegerMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldIntegerMapper.cs
@@ -56,9 +56,13 @@ namespace Glass.Mapper.Sc.DataMappers
         {
             if (fieldValue.IsNullOrEmpty()) return DefaultValue;
             int dValue = (int)DefaultValue;
-            int.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue);
 
-            return dValue;
+            if (int.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue))
+            {
+                return dValue;
+            }
+
+            return Int32.MinValue;
         }
 
         /// <summary>

--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldIntegerMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldIntegerMapper.cs
@@ -50,14 +50,15 @@ namespace Glass.Mapper.Sc.DataMappers
         /// <param name="config">The config.</param>
         /// <param name="context">The context.</param>
         /// <returns>System.Object.</returns>
-        /// <exception cref="Glass.Mapper.MapperException">Could not convert value to double</exception>
+        /// <exception cref="Glass.Mapper.MapperException">Could not convert value to System.Integer</exception>
         public override object GetFieldValue(string fieldValue, SitecoreFieldConfiguration config,
                                              SitecoreDataMappingContext context)
         {
-            if (fieldValue.IsNullOrEmpty()) return 0;
-            int dValue = 0;
-            if (int.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue)) return dValue;
-            else throw new MapperException("Could not convert value to Integer");
+            if (fieldValue.IsNullOrEmpty()) return DefaultValue;
+            int dValue = (int)DefaultValue;
+            int.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue);
+
+            return dValue;
         }
 
         /// <summary>
@@ -67,7 +68,7 @@ namespace Glass.Mapper.Sc.DataMappers
         /// <param name="config">The config.</param>
         /// <param name="context">The context.</param>
         /// <returns>System.String.</returns>
-        /// <exception cref="System.NotSupportedException">The value is not of type System.Double</exception>
+        /// <exception cref="System.NotSupportedException">The value is not of type System.Integer</exception>
         public override string SetFieldValue(object value, SitecoreFieldConfiguration config, SitecoreDataMappingContext context)
         {
             if (value is int)

--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldLongMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldLongMapper.cs
@@ -49,14 +49,14 @@ namespace Glass.Mapper.Sc.DataMappers
         /// <param name="config">The config.</param>
         /// <param name="context">The context.</param>
         /// <returns>System.Object.</returns>
-        /// <exception cref="Glass.Mapper.MapperException">Could not convert value to double</exception>
         public override object GetFieldValue(string fieldValue, SitecoreFieldConfiguration config,
                                              SitecoreDataMappingContext context)
         {
-            if (fieldValue.IsNullOrEmpty()) return (long)0;
-            long dValue = 0;
-            if (long.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue)) return dValue;
-            else throw new MapperException("Could not convert value to double");
+            if (fieldValue.IsNullOrEmpty()) return DefaultValue;
+            long dValue = (long)DefaultValue;
+            long.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue);
+
+            return dValue;
         }
 
         /// <summary>

--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldLongMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldLongMapper.cs
@@ -54,9 +54,13 @@ namespace Glass.Mapper.Sc.DataMappers
         {
             if (fieldValue.IsNullOrEmpty()) return DefaultValue;
             long dValue = (long)DefaultValue;
-            long.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue);
 
-            return dValue;
+            if (long.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue))
+            {
+                return dValue;
+            }
+
+            return long.MinValue;
         }
 
         /// <summary>


### PR DESCRIPTION
This pull requests removes the throwing of a GlassMapperException within the Number DataMappers if unable to parse to that type.

Reasoning:

I noticed within a Sitecore 7.2 (rev. 141226) instance, that when editing a Integer field type within the Page Editor, if I put something outrageous, say, 1000000000000000000000, and hit save Sitecore would accept the change (field type is Integer, validation of 'Is Integer' applied to field). After the save, Glass would throw an exception any time the field was accessed.

In these scenarios, I think it would be better to return a MinValue and let the developer handle those occurrences then to create a wrapper around the fields to catch those exceptions.