### PR TITLE
Fixing a race condition in the ModelCacheManager

### DIFF
--- a/Source/Glass.Mapper.Sc.Mvc/ModelCache/ModelCacheManager.cs
+++ b/Source/Glass.Mapper.Sc.Mvc/ModelCache/ModelCacheManager.cs
@@ -52,23 +52,13 @@ namespace Glass.Mapper.Sc.ModelCache
 
         public virtual Type Get(string path)
         {
-            return CachedTypes.ContainsKey(path) ? CachedTypes[path] : null;
+            Type retVal;
+            return CachedTypes.TryGetValue(path, out retVal) ? retVal : null;
         }
 
         public string GetKey(string path)
         {
-            string realPath;
-            if (CachedKeys.ContainsKey(path))
-            {
-                realPath = CachedKeys[path];
-            }
-            else
-            {
-                realPath = HttpContext.Current.Server.MapPath(path);
-                CachedKeys.TryAdd(path, realPath);
-            }
-
-            return realPath;
+           return CachedKeys.GetOrAdd(path, key => HttpContext.Current.Server.MapPath(key));            
         }
     }
 }


### PR DESCRIPTION
Hi Mike,

Congrats on the V4 release.

I was reviewing some of the new additions (very excited about some of these by the way), and noticed a minor issue with the ModelCacheManager.

In rare instances where razor files are getting touched/changed on disk, the ModelCacheManager may end up invalidating cache items as they are being retrieved in the Get function, potentially throwing a KeyNotFoundException.

I've modified the code to use the ConcurrentDictionary's built-in TryGetValue method to prevent this from happening.  Also, I've taken the liberty of rewriting the GetKey function as well; while it's currently not a problem, if the CachedKeys dictionary were to ever have its values removed at any point in the future, this function would no longer work as intended.