### PR TITLE
Enable override of SitecoreTypeConfiguration

### DIFF
--- a/Source/Glass.Mapper.Sc/Configuration/Fluent/SitecoreType.cs
+++ b/Source/Glass.Mapper.Sc/Configuration/Fluent/SitecoreType.cs
@@ -37,11 +37,19 @@ namespace Glass.Mapper.Sc.Configuration.Fluent
         /// </summary>
         public SitecoreType()
         {
-            _configuration = new SitecoreTypeConfiguration();
+            _configuration = CreateSitecoreTypeConfiguration();
             _configuration.Type = typeof (T);
             _configuration.ConstructorMethods = Utilities.CreateConstructorDelegates(_configuration.Type);
+        }
 
-
+        /// <summary>
+        /// Instantiates <see cref="SitecoreTypeConfiguration"/>.
+        /// Override this method to use another implementation
+        /// </summary>
+        /// <returns></returns>
+        protected virtual SitecoreTypeConfiguration CreateSitecoreTypeConfiguration()
+        {
+            return new SitecoreTypeConfiguration();
         }
 
         /// <summary>


### PR DESCRIPTION
I would really like to change the way AutoMapping works (basically a convention for generating Sitecore field names).
I have found that I can inherit from the SitecoreTypeConfiguration and override the AutoMapProperty method with our convention, however I cannot see how I can get this into use without this pull request.

With this pull request I can inherit from SitecoreType and override the instatiation of SitecoreTypeConfiguration. My GlassMaps (for fluent configuration) can then override the CreateGlassType method and return the new inherited SitecoreType.

As I can see, an alternatives could be to resolve SitecoreTypeConfiguration from the DependencyResolver, but then i guess the SitecoreType must know the GlassContext, which is currently not the case.
Another alternative could be to move the automap related logic from the SitecoreTypeConfiguration to some kind of automapping strategies, but that would definitely be a bigger refactoring.

Hope you can accept this and don't hesitate to comment if you have better ways of to do this.