### PR TITLE
Change order of base class call.

### DIFF
--- a/Source/Glass.Mapper.Sc/SitecoreService.cs
+++ b/Source/Glass.Mapper.Sc/SitecoreService.cs
@@ -98,14 +98,14 @@ namespace Glass.Mapper.Sc
 
         public override void Initiate(IDependencyResolver resolver)
         {
+            Config = resolver.GetConfig() as Config;
+            
             base.Initiate(resolver);
             
             CacheEnabled = Sitecore.Context.Site == null ||
                            (!Sitecore.Context.PageMode.IsPageEditor &&
                             !Sitecore.Context.PageMode.IsPageEditorEditing &&
                             (Sitecore.Context.Site != null && Sitecore.Context.Site.Properties["glassCache"] == "true"));
-
-            Config = resolver.GetConfig() as Config ;
         }
 
 

--- a/Source/Glass.Mapper.Sc/SitecoreService.cs
+++ b/Source/Glass.Mapper.Sc/SitecoreService.cs
@@ -98,13 +98,14 @@ namespace Glass.Mapper.Sc
 
         public override void Initiate(IDependencyResolver resolver)
         {
+            base.Initiate(resolver);
+            
             CacheEnabled = Sitecore.Context.Site == null ||
                            (!Sitecore.Context.PageMode.IsPageEditor &&
                             !Sitecore.Context.PageMode.IsPageEditorEditing &&
                             (Sitecore.Context.Site != null && Sitecore.Context.Site.Properties["glassCache"] == "true"));
 
             Config = resolver.GetConfig() as Config ;
-            base.Initiate(resolver);
         }
 
 


### PR DESCRIPTION
Each `<site>` can have a property `glassCache` and the cache for Glass should only be enabled if the site has this property. Now because the base class of `SitecoreService` always sets `CacheEnabled` to `true` and the base method is called at the end of the method, the setting is always overrriden and is always `true`. This means that there is now way of disabling cache on an authoring environment in normal mode. Calling the base `Initiate()` method at the beginning should fix this.

Cheers,
Kevin