### PR TITLE
Fix "save & read" issues in number types

### DIFF
--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldDecimalMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldDecimalMapper.cs
@@ -68,12 +68,13 @@ namespace Glass.Mapper.Sc.DataMappers
         /// <exception cref="System.NotSupportedException">The value is not of type System.Decimal</exception>
         public override string SetFieldValue(object value, SitecoreFieldConfiguration config, SitecoreDataMappingContext context)
         {
-            if (value is decimal)
+            decimal? decimalValue = value as decimal?;
+            if (decimalValue.HasValue)
             {
-                return value.ToString();
+                return decimalValue.Value.ToString(CultureInfo.InvariantCulture);
             }
-            else
-                throw new NotSupportedException("The value is not of type System.Decimal");
+
+            throw new NotSupportedException("The value is not of type System.Decimal");
         }
     }
 }

--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldDoubleMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldDoubleMapper.cs
@@ -69,12 +69,13 @@ namespace Glass.Mapper.Sc.DataMappers
         /// <exception cref="System.NotSupportedException">The value is not of type System.Double</exception>
         public override string SetFieldValue(object value, SitecoreFieldConfiguration config, SitecoreDataMappingContext context)
         {
-            if (value is double)
+            double? doubleValue = value as double?;
+            if (doubleValue.HasValue)
             {
-                return value.ToString();
+                return doubleValue.Value.ToString(CultureInfo.InvariantCulture);
             }
-            else
-                throw new NotSupportedException("The value is not of type System.Double");
+
+            throw new NotSupportedException("The value is not of type System.Double");
         }
     }
 }

--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldFloatMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldFloatMapper.cs
@@ -56,7 +56,7 @@ namespace Glass.Mapper.Sc.DataMappers
             if (fieldValue.IsNullOrEmpty()) return 0f;
             float dValue = 0f;
             if (float.TryParse(fieldValue, NumberStyles.Any, CultureInfo.InvariantCulture, out dValue)) return dValue;
-            else throw new MapperException("Could not convert value to double");
+            else throw new MapperException("Could not convert value to float");
         }
 
         /// <summary>
@@ -66,15 +66,16 @@ namespace Glass.Mapper.Sc.DataMappers
         /// <param name="config">The config.</param>
         /// <param name="context">The context.</param>
         /// <returns>System.String.</returns>
-        /// <exception cref="System.NotSupportedException">The value is not of type System.Double</exception>
+        /// <exception cref="System.NotSupportedException">The value is not of type System.Float</exception>
         public override string SetFieldValue(object value, SitecoreFieldConfiguration config, SitecoreDataMappingContext context)
         {
-            if (value is float)
+            float? floatValue = value as float?;
+            if (floatValue.HasValue)
             {
-                return value.ToString();
+                return floatValue.Value.ToString(CultureInfo.InvariantCulture);
             }
-            else
-                throw new NotSupportedException("The value is not of type System.Float");
+
+            throw new NotSupportedException("The value is not of type System.Float");
         }
     }
 }


### PR DESCRIPTION
The usage of the ToString() method on the number types has a different output based on the current thread culture. In my case, this is de-CH (Which differs from the .Net one because of an Patch from Microsoft from last year) with an "," as the NumberInfo.NumberDecimalSeparator. 

If i use the SetFieldValue method in this culture, the field value within Sitecore is "17,8" as an example.

The GetFieldValue in comparison uses The InvariantCulture for parsing the string into the specific number type. InvariantCulture expects an "." as the delimiter, otherwise the TryParse would result in "178" instead of "17.8".

Because of this issue, Saving items with such data types is not possible without changing the Thread.CurrentCulture temporary to a culture which uses "." as the delimiter (e.g. en-US).

I created an simple console program which shows the issue based on two different cultures and same calls used in the Data Mappers:

https://gist.github.com/rootix/80cdb84481a753809396

This pull request casts the types to their real types to support the CultureInfo parameter for saving the correct value.

Let me know if you think it needs more polish.

Regards,
Pascal 
