### PR TITLE
Update RenderingContextUserControlWrapper.cs

### DIFF
--- a/Source/Glass.Mapper.Sc/Web/Ui/RenderingContextUserControlWrapper.cs
+++ b/Source/Glass.Mapper.Sc/Web/Ui/RenderingContextUserControlWrapper.cs
@@ -37,7 +37,7 @@ namespace Glass.Mapper.Sc.Web.Ui
         {
             if (control == null) return null;
 
-            var sublayout = _control as Sublayout;
+            var sublayout = control as Sublayout;
             if (sublayout != null)
             {
                 return sublayout.Parameters;


### PR DESCRIPTION
referring to "_control" instead on the parameter "control" is wrong in this recursive method.
The method does always return null for an user control (not a sublayout)