### PR TITLE
Fix for the interface-driven models always being loaded lazily

### DIFF
--- a/Source/Glass.Mapper/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfacePropertyInterceptor.cs
+++ b/Source/Glass.Mapper/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfacePropertyInterceptor.cs
@@ -31,9 +31,15 @@ namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateInterface
         [NonSerialized]
 		private ObjectConstructionArgs _args;
 
-		private readonly Lazy<IDictionary<string, object>> _lazyValues;
+        /// <summary>
+        /// Lazy initializer for model properties
+        /// </summary>
+		protected readonly Lazy<IDictionary<string, object>> LazyValues;
 
-		protected IDictionary<string, object> Values { get { return _lazyValues.Value; } }
+        /// <summary>
+        /// The underlying model's property dictionary
+        /// </summary>
+		protected virtual IDictionary<string, object> Values { get { return LazyValues.Value; } }
 
 	    private readonly string _fullName;
 
@@ -45,7 +51,13 @@ namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateInterface
 		{
 			_args = args;
 		    _fullName = _args.Configuration.Type.FullName;
-			_lazyValues = new Lazy<IDictionary<string, object>>(LoadValues);
+			LazyValues = new Lazy<IDictionary<string, object>>(LoadValues);
+
+		    if (!args.AbstractTypeCreationContext.IsLazy)
+		    {
+                // Force the lazy values to be eagerly loaded
+		        var value = LazyValues.Value;
+		    }
 		}
 
 		/// <summary>

--- a/Tests/Unit Tests/Glass.Mapper.Tests/Glass.Mapper.Tests.csproj
+++ b/Tests/Unit Tests/Glass.Mapper.Tests/Glass.Mapper.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Pipelines\ConfigurationResolver\Tasks\StandardResolver\ConfigurationStandardResolverTaskFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateConcrete\LazyObjectInterceptorFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateInterface\CreateInterfaceTaskFixture.cs" />
+    <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateInterface\InterfaceProperterInterceptorFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateInterface\InterfaceSerializationFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateMultitInterface\CreateMultiInterfaceTaskFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateMultitInterface\MultiInterfacePropertyInterceptorFixture.cs" />

--- a/Tests/Unit Tests/Glass.Mapper.Tests/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfaceProperterInterceptorFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Tests/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfaceProperterInterceptorFixture.cs
@@ -45,7 +45,7 @@ namespace Glass.Mapper.Tests.Pipelines.ObjectConstruction.Tasks.CreateInterface
             var invocation = Substitute.For<IInvocation>();
             invocation.Method.Returns(typeof(IStubInterfaceWithProp).GetProperty("StubProp").GetMethod);
 
-            //Preconditional Assert; ensure that we haven't yet received any calls to the underlying datasource
+            //Preconditional Assert; ensure that we haven't yet received any calls to the underlying datasource (via access to the LazyValues property)
             Assert.IsFalse(interceptor.ValuesCalled);
 
             //Act
@@ -65,7 +65,7 @@ namespace Glass.Mapper.Tests.Pipelines.ObjectConstruction.Tasks.CreateInterface
             var invocation = Substitute.For<IInvocation>();
             invocation.Method.Returns(typeof(IStubInterfaceWithProp).GetProperty("StubProp").GetMethod);
 
-            //Preconditional Assert; ensure that we haven't yet received any calls to the underlying datasource
+            //Preconditional Assert; ensure that we have already received the call to the underlying datasource (via access to the LazyValues property)
             Assert.IsTrue(interceptor.ValuesCalled);
 
             //Act

--- a/Tests/Unit Tests/Glass.Mapper.Tests/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfaceProperterInterceptorFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Tests/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfaceProperterInterceptorFixture.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Castle.DynamicProxy;
+using Glass.Mapper.Configuration;
+using Glass.Mapper.IoC;
+using Glass.Mapper.Pipelines.ObjectConstruction;
+using Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateInterface;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Glass.Mapper.Tests.Pipelines.ObjectConstruction.Tasks.CreateInterface
+{
+    [TestFixture]
+    public class InterfacePropertyInterceptorFixture
+    {
+        private ObjectConstructionArgs _args;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            Type type = typeof(IStubInterfaceWithProp);
+            var service = Substitute.For<IAbstractService>();
+
+            Context context = Context.Create(Substitute.For<IDependencyResolver>());
+
+            var abstractCreationContext = Substitute.For<AbstractTypeCreationContext>();
+            abstractCreationContext.RequestedType = typeof(IStubInterfaceWithProp);
+            abstractCreationContext.IsLazy = false;
+
+            var configuration = Substitute.For<AbstractTypeConfiguration>();
+            configuration.Type = type;
+
+            _args = new ObjectConstructionArgs(context, abstractCreationContext, configuration, service);
+        }
+
+        #region Method - cctor & Intercept
+
+        [Test]
+        public void Execute_LazyCreationContext_ValuesLoadedLazily()
+        {
+            //Assign
+            _args.AbstractTypeCreationContext.IsLazy = true;
+            var interceptor = new TestInterfacePropertyInterceptor(_args);
+
+            var invocation = Substitute.For<IInvocation>();
+            invocation.Method.Returns(typeof(IStubInterfaceWithProp).GetProperty("StubProp").GetMethod);
+
+            //Preconditional Assert; ensure that we haven't yet received any calls to the underlying datasource
+            Assert.IsFalse(interceptor.ValuesCalled);
+
+            //Act
+            interceptor.Intercept(invocation);
+            
+            //Assert
+            Assert.IsTrue(interceptor.ValuesCalled);
+        }
+
+        [Test]
+        public void Execute_LazyContextDisabled_ValuesLoadedEagerly()
+        {
+            //Assign
+            _args.AbstractTypeCreationContext.IsLazy = false;
+            var interceptor = new TestInterfacePropertyInterceptor(_args);
+
+            var invocation = Substitute.For<IInvocation>();
+            invocation.Method.Returns(typeof(IStubInterfaceWithProp).GetProperty("StubProp").GetMethod);
+
+            //Preconditional Assert; ensure that we haven't yet received any calls to the underlying datasource
+            Assert.IsTrue(interceptor.ValuesCalled);
+
+            //Act
+            interceptor.Intercept(invocation);
+
+            //Assert
+            Assert.IsTrue(interceptor.ValuesCalled);
+        }
+
+        #endregion
+
+        #region Stubs
+
+        public interface IStubInterfaceWithProp
+        {
+            string StubProp { get; }
+        }
+
+        #endregion
+
+        #region Test Helpers
+        
+        public class TestInterfacePropertyInterceptor : InterfacePropertyInterceptor
+        {
+            public bool ValuesCalled => LazyValues.IsValueCreated;
+            
+            public TestInterfacePropertyInterceptor(ObjectConstructionArgs args) : base(args)
+            {
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
The InterfacePropertyInterceptor would always load model properties lazily, irrespective of the AbstractTypeCreationContext's IsLazy configuration value.  This change ensures that when a model is requested with 'isLazy' set to false, the returned model will eagerly load all property values at construction time, as opposed to first property access time.

This change should also ensure that interface-driven models can be safely cached using Glass.Mapper's v4 caching facility, without fear of lazy-instantiation issues.