### PR TITLE
Fix for Issue #207

### DIFF
--- a/Source/Glass.Mapper.Sc.Mvc/Web/Mvc/GlassHtmlMvc.cs
+++ b/Source/Glass.Mapper.Sc.Mvc/Web/Mvc/GlassHtmlMvc.cs
@@ -183,21 +183,7 @@ namespace Glass.Mapper.Sc.Web.Mvc
 
 
 
-        /// <summary>
-        /// Renders an image allowing simple page editor support
-        /// </summary>
-        /// <typeparam name="T">The model type</typeparam>
-        /// <param name="model">The model that contains the image field</param>
-        /// <param name="field">A lambda expression to the image field, should be of type Glass.Mapper.Sc.Fields.Image</param>
-        /// <param name="parameters">Image parameters, e.g. width, height</param>
-        /// <param name="isEditable">Indicates if the field should be editable</param>
-        /// <returns></returns>
-        public virtual HtmlString RenderImage<T>(T model, Expression<Func<T, object>> field,
-            object parameters = null,
-            bool isEditable = false)
-        {
-            return new HtmlString(GlassHtml.RenderImage(model, field, parameters, isEditable));
-        }
+
 
 
 
@@ -234,12 +220,14 @@ namespace Glass.Mapper.Sc.Web.Mvc
         /// <param name="field">A lambda expression to the image field, should be of type Glass.Mapper.Sc.Fields.Image</param>
         /// <param name="parameters">Image parameters, e.g. width, height</param>
         /// <param name="isEditable">Indicates if the field should be editable</param>
+        /// <param name="outputHeightWidth">Indicates if the height and width attributes should be outputted when rendering the image</param>
         /// <returns></returns>
         public virtual HtmlString RenderImage(Expression<Func<TK, object>> field,
             object parameters = null,
-            bool isEditable = false)
+            bool isEditable = false,
+            bool outputHeightWidth = true)
         {
-            return new HtmlString(GlassHtml.RenderImage(Model, field, parameters, isEditable));
+            return new HtmlString(GlassHtml.RenderImage(Model, field, parameters, isEditable, outputHeightWidth));
         }
 
         /// <summary>


### PR DESCRIPTION
PR that resolves #207

Removes second extension method that had the same method signature as RenderImage(T model, . . .) but with a different number of optional parameters.

C# does not allow two methods to differ only by optional parameters, as it gets confused about which method you want to call when you do not specify any optional parameters in the call.

Additionally adds the outputHeightWidth optional parameter to the standard RenderImage that points at the page Model to bring it in-line with how the model injected method works. 
