### PR TITLE
Change log statements to Debug instead of Info.

### DIFF
--- a/Source/Glass.Mapper.Sc.Mvc/Pipelines/Response/GetModel.cs
+++ b/Source/Glass.Mapper.Sc.Mvc/Pipelines/Response/GetModel.cs
@@ -66,7 +66,7 @@ namespace Glass.Mapper.Sc.Pipelines.Response
             get
             {
                 var context = AbstractSitecoreContext.GetContextFromSite();
-                Sitecore.Diagnostics.Log.Info("using context " + context, this);
+                Sitecore.Diagnostics.Log.Debug("using context " + context, this);
                 return context;
             }
         }
@@ -78,7 +78,7 @@ namespace Glass.Mapper.Sc.Pipelines.Response
         /// <param name="args">The args.</param>
         public override void Process(GetModelArgs args)
         {
-            Sitecore.Diagnostics.Log.Info("Glass GetModel Process " + ContextName, this);
+            Sitecore.Diagnostics.Log.Debug("Glass GetModel Process " + ContextName, this);
 
             if (args.Result == null)
             {

--- a/Source/Glass.Mapper.Sc.Mvc/Pipelines/Response/GetModelFromView.cs
+++ b/Source/Glass.Mapper.Sc.Mvc/Pipelines/Response/GetModelFromView.cs
@@ -34,7 +34,7 @@ namespace Glass.Mapper.Sc.Pipelines.Response
             get
             {
                 var context = AbstractSitecoreContext.GetContextFromSite();
-                Sitecore.Diagnostics.Log.Info("using context " + context, this);
+                Sitecore.Diagnostics.Log.Debug("using context " + context, this);
                 return context;
             }
         }


### PR DESCRIPTION
The recently added log statements fill the log file because it logs 3 statements for every execution of the `mvc.getModel` pipeline.