### PR TITLE
Support FieldId mapping with edit frames

### DIFF
--- a/Source/Glass.Mapper.Sc/GlassHtml.cs
+++ b/Source/Glass.Mapper.Sc/GlassHtml.cs
@@ -162,14 +162,14 @@ namespace Glass.Mapper.Sc
             {
                 if (fields.Any())
                 {
-                    var fieldNames = fields.Select(x => Mapper.Utilities.GetGlassProperty<T, SitecoreTypeConfiguration>(x, this.SitecoreContext.GlassContext, model))
+                    var fieldIdsOrNames = fields.Select(x => Mapper.Utilities.GetGlassProperty<T, SitecoreTypeConfiguration>(x, this.SitecoreContext.GlassContext, model))
                         .Cast<SitecoreFieldConfiguration>()
                         .Where(x => x != null)
-                        .Select(x => x.FieldName);
+                        .Select(x => x.FieldId != (ID)null ? x.FieldId.ToString() : x.FieldName);
 
                     var buttonPath = "{0}{1}".Formatted(
                         EditFrameBuilder.BuildToken,
-                        fieldNames.Aggregate((x, y) => x + "|" + y));
+                        string.Join("|", fieldIdsOrNames));
 
                     if (title.IsNotNullOrEmpty())
                     {


### PR DESCRIPTION
This adds support for using fields in edit frames mapped by field id instead of field name. If a field does not have an id mapping it falls back to using field name as before.