### PR TITLE
Ensuring thread-safety in InterfacePropertyInterceptor

### DIFF
--- a/Source/Glass.Mapper/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfacePropertyInterceptor.cs
+++ b/Source/Glass.Mapper/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfacePropertyInterceptor.cs
@@ -17,6 +17,7 @@
 //-CRE-
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -50,7 +51,7 @@ namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateInterface
         {
             _args = args;
             _fullName = _args.Configuration.Type.FullName;
-            Values = new Dictionary<string, object>();
+            Values = new ConcurrentDictionary<string, object>();
 
             _mappingContext = _args.Service.CreateDataMappingContext(_args.AbstractTypeCreationContext, null);
 
@@ -63,7 +64,7 @@ namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateInterface
 
         public InterfacePropertyInterceptor(SerializationInfo info, StreamingContext context)
         {
-           Values = (Dictionary<string, object>) info.GetValue("Values", typeof(Dictionary<string, object>));
+           Values = (ConcurrentDictionary<string, object>) info.GetValue("Values", typeof(ConcurrentDictionary<string, object>));
 
         }
 
@@ -87,13 +88,12 @@ namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateInterface
 
                     if (method == "get_")//&& Values.ContainsKey(name))
                     {
-                        if (Values.ContainsKey(name))
+                        object result;
+                        if (Values.TryGetValue(name, out result))
                         {
-                            var result = Values[name];
                             invocation.ReturnValue = result;
                             return;
                         }
-
 
                         var property = _args == null ? null: _args.Configuration.Properties.FirstOrDefault(x => x.PropertyInfo.Name == name);
                         if (property != null)

--- a/Tests/Unit Tests/Glass.Mapper.Tests/Glass.Mapper.Tests.csproj
+++ b/Tests/Unit Tests/Glass.Mapper.Tests/Glass.Mapper.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Pipelines\ConfigurationResolver\Tasks\StandardResolver\ConfigurationStandardResolverTaskFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateConcrete\LazyObjectInterceptorFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateInterface\CreateInterfaceTaskFixture.cs" />
+    <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateInterface\InterfacePropertyInterceptorFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateInterface\InterfaceSerializationFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateMultitInterface\CreateMultiInterfaceTaskFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateMultitInterface\MultiInterfacePropertyInterceptorFixture.cs" />

--- a/Tests/Unit Tests/Glass.Mapper.Tests/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfacePropertyInterceptorFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Tests/Pipelines/ObjectConstruction/Tasks/CreateInterface/InterfacePropertyInterceptorFixture.cs
@@ -1,0 +1,217 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Castle.DynamicProxy;
+using Glass.Mapper.Configuration;
+using Glass.Mapper.Pipelines.ObjectConstruction;
+using Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CreateInterface;
+using NSubstitute;
+
+namespace Glass.Mapper.Tests.Pipelines.ObjectConstruction.Tasks.CreateInterface
+{
+    [TestFixture]
+    public class InterfacePropertyInterceptorFixture
+    {
+        #region Method - Intercept
+
+        [Test]
+        public void Intercept_WithMultiplePropertiesAndLazyLoading_ReturnsExpectedPropertyValues()
+        {
+            //Arrange   
+            var service = Substitute.For<IAbstractService>();
+            var config = new StubAbstractTypeConfiguration();
+            var context = Substitute.For<AbstractTypeCreationContext>();
+
+            config.Type = typeof(IStubTarget);
+            context.IsLazy = true;
+
+            var args = new ObjectConstructionArgs(null, context, config, service)
+            {
+                Parameters = new Dictionary<string, object>()
+            };
+            var interceptor = new InterfacePropertyInterceptor(args);
+            var invocations = new List<IInvocation>();
+
+            for (var i = 0; i < 100; i++)
+            {
+                invocations.Add(CreateInterceptedProperty(config, i.ToString()));
+            }
+
+            //Act
+            foreach (var invocation in invocations)
+            {
+                interceptor.Intercept(invocation);
+
+                // Assert
+                Assert.AreEqual(invocation.Method.Name.Substring(4), invocation.ReturnValue);
+            }
+        }
+
+        [Test]
+        public void Intercept_InterceptsProperties_ReturnsExpectedPropertyValue()
+        {
+            //Arrange   
+            var service = Substitute.For<IAbstractService>();
+            var config = new StubAbstractTypeConfiguration();
+            var context = Substitute.For<AbstractTypeCreationContext>();
+
+            var property = new StubAbstractPropertyConfiguration();
+            var mapper = new StubAbstractDataMapper();
+
+            var expected = "test random 1";
+            var propertyName = "Property1";
+
+            var info = new FakePropertyInfo(typeof(string), propertyName, typeof(IStubTarget));
+
+            config.AddProperty(property);
+            config.Type = typeof(IStubTarget);
+
+            property.Mapper = mapper;
+            property.PropertyInfo = info;
+
+            mapper.Value = expected;
+
+            var args = new ObjectConstructionArgs(null, context, config, service)
+            {
+                Parameters = new Dictionary<string, object>()
+            };
+            var interceptor = new InterfacePropertyInterceptor(args);
+
+            var invocation = Substitute.For<IInvocation>();
+
+            invocation.Method.Returns(typeof(IStubTarget).GetProperty(propertyName).GetGetMethod());
+
+            //Act
+            interceptor.Intercept(invocation);
+
+            //Assert
+            Assert.AreEqual(expected, invocation.ReturnValue);
+        }
+
+        [Test]
+        public void Intercept_InterceptsProperties_SetsExpectedPropertyValue()
+        {
+            //Arrange   
+            var service = Substitute.For<IAbstractService>();
+            var config = new StubAbstractTypeConfiguration();
+            var context = Substitute.For<AbstractTypeCreationContext>();
+
+            var property = new StubAbstractPropertyConfiguration();
+            var mapper = new StubAbstractDataMapper();
+
+            var expected = "test random 1";
+            var propertyName = "Property1";
+
+            var info1 = new FakePropertyInfo(typeof(string), propertyName, typeof(IStubTarget));
+
+            config.AddProperty(property);
+            config.Type = typeof(IStubTarget);
+
+            property.Mapper = mapper;
+            property.PropertyInfo = info1;
+
+            var args = new ObjectConstructionArgs(null, context, config, service)
+            {
+                Parameters = new Dictionary<string, object>()
+            };
+            var interceptor = new InterfacePropertyInterceptor(args);
+
+            var setInvocation = Substitute.For<IInvocation>();
+            setInvocation.Arguments.Returns(new[] { expected });
+            setInvocation.Method.Returns(typeof(IStubTarget).GetProperty(propertyName).GetSetMethod());
+
+            //Act
+            interceptor.Intercept(setInvocation);
+
+            //Assert
+            var getInvocation = Substitute.For<IInvocation>();
+
+            getInvocation.Method.Returns(typeof(IStubTarget).GetProperty(propertyName).GetGetMethod());
+
+            interceptor.Intercept(getInvocation);
+
+            Assert.AreEqual(expected, getInvocation.ReturnValue);
+        }
+
+
+        #endregion
+
+        #region Stubs
+
+        public class StubAbstractTypeConfiguration : AbstractTypeConfiguration
+        {
+
+        }
+
+        public class StubAbstractPropertyConfiguration : AbstractPropertyConfiguration
+        {
+            protected override AbstractPropertyConfiguration CreateCopy()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class StubAbstractDataMapper : AbstractDataMapper
+        {
+            public string Value { get; set; }
+            public override void MapToCms(AbstractDataMappingContext mappingContext)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override object MapToProperty(AbstractDataMappingContext mappingContext)
+            {
+                return Value;
+            }
+
+            public override bool CanHandle(AbstractPropertyConfiguration configuration, Context context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public interface IStubTarget
+        {
+            string Property1 { get; set; }
+        }
+
+        #endregion
+
+        #region Test Helpers
+
+
+        private static IInvocation CreateInterceptedProperty(StubAbstractTypeConfiguration config, string propertyName)
+        {
+            var invocation = Substitute.For<IInvocation>();
+
+            var property = new StubAbstractPropertyConfiguration();
+            var mapper = new StubAbstractDataMapper();
+
+            var getter = Substitute.For<MethodInfo>();
+            getter.Attributes.Returns(MethodAttributes.SpecialName);
+            getter.Name.Returns("get_" + propertyName);
+            getter.ReturnType.Returns(typeof(string));
+
+            var returnValue = propertyName;
+            var info = Substitute.For<FakePropertyInfo>(typeof(string), propertyName, typeof(IStubTarget));
+            info.CanWrite.Returns(false);
+            info.DeclaringType.Returns(typeof(IStubTarget));
+            info.Name.Returns(propertyName);
+
+            property.Mapper = mapper;
+            property.PropertyInfo = info;
+
+            config.AddProperty(property);
+
+            mapper.Value = returnValue;
+
+            invocation.Method.Returns(getter);
+
+            return invocation;
+        }
+
+        #endregion
+
+    }
+}


### PR DESCRIPTION
Hi Mike,

I've been reviewing some of the recent changes in the InterfacePropertyInterceptor class, and wanted to contribute back a few things:

1. **Ensure that lazy loaded properties are populated in a thread-safe manner**
  * I noticed that when the properties are loaded lazily, there's the potential for concurrency issues due to multiple threads updating the underlying Dictionary collection.  Switching to a ConcurrentDictionary solves this issue.
2. **Ensure safety for pre-emptive serialization**
  * _It's unclear to me if this is currently being used, but just in case..._
  * With the new serialization mechanism (implementing ISerializable), it's possible for a glass model using the InterfacePropertyInterceptor to be serialized on another thread with only a partially populated Values collection.  In this case, serialization forces all values to be loaded, which can cause issues with other inserts that are in-flight.  This is also solved by switching to the ConcurrentDictionary.
3. **Unit Tests**