### PR TITLE
Specify data mapper per property using attribute configuration

### DIFF
--- a/Source/Glass.Mapper/Configuration/Attributes/DataMapperAttribute.cs
+++ b/Source/Glass.Mapper/Configuration/Attributes/DataMapperAttribute.cs
@@ -1,0 +1,37 @@
+﻿/*
+   Copyright 2012 Michael Edwards
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+//-CRE-
+
+using System;
+
+namespace Glass.Mapper.Configuration.Attributes
+{
+    /// <summary>
+    /// Specifies the type of data mapper to use when mapping this property.
+    /// The type must inherit from <see cref="AbstractDataMapper"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class DataMapperAttribute : Attribute
+    {
+        public Type DataMapperType { get; }
+
+        public DataMapperAttribute(Type dataMapperType)
+        {
+            DataMapperType = dataMapperType;
+        }
+    }
+}

--- a/Source/Glass.Mapper/Glass.Mapper.csproj
+++ b/Source/Glass.Mapper/Glass.Mapper.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Configuration\Attributes\AttributeTypeLoader.cs" />
     <Compile Include="Configuration\Attributes\ChildrenAttribute.cs" />
     <Compile Include="Configuration\Attributes\AbstractTypeAttribute.cs" />
+    <Compile Include="Configuration\Attributes\DataMapperAttribute.cs" />
     <Compile Include="Configuration\Attributes\IdAttribute.cs" />
     <Compile Include="Configuration\Attributes\IgnoreAttribute.cs" />
     <Compile Include="Configuration\Attributes\InfoAttribute.cs" />

--- a/Source/Glass.Mapper/Pipelines/DataMapperResolver/Tasks/DataMapperStandardResolverTask.cs
+++ b/Source/Glass.Mapper/Pipelines/DataMapperResolver/Tasks/DataMapperStandardResolverTask.cs
@@ -1,6 +1,6 @@
 /*
    Copyright 2012 Michael Edwards
- 
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
@@ -12,12 +12,15 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
- 
-*/ 
+
+*/
 //-CRE-
 
-
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using Glass.Mapper.Configuration.Attributes;
 
 namespace Glass.Mapper.Pipelines.DataMapperResolver.Tasks
 {
@@ -26,28 +29,80 @@ namespace Glass.Mapper.Pipelines.DataMapperResolver.Tasks
     /// </summary>
     public class DataMapperStandardResolverTask : AbstractDataMapperResolverTask
     {
+        private Dictionary<PropertyInfo, AbstractDataMapper> AttributeMappers { get; }
+
         public DataMapperStandardResolverTask()
         {
             Name = "DataMapperStandardResolverTask";
+            AttributeMappers = new Dictionary<PropertyInfo, AbstractDataMapper>();
         }
+
         /// <summary>
         /// Executes the specified args.
         /// </summary>
         /// <param name="args">The args.</param>
-        /// <exception cref="Glass.Mapper.MapperException">Could not find data mapper to handler property {0}.Formatted(args.PropertyConfiguration)</exception>
+        /// <exception cref="Glass.Mapper.MapperException">Could not find data mapper to handle property {0}.Formatted(args.PropertyConfiguration)</exception>
         public override void Execute(DataMapperResolverArgs args)
         {
             if (args.Result == null)
             {
-                var mapper = args.DataMappers.FirstOrDefault(x => x.CanHandle(args.PropertyConfiguration, args.Context));
-                
-                if(mapper == null) 
+                var mapper = LoadFromDataMapperAttribute(args) ??
+                             args.DataMappers.FirstOrDefault(x => x.CanHandle(args.PropertyConfiguration, args.Context));
+
+                if(mapper == null)
                     throw new MapperException("Could not find a data mapper to handle property {0}".Formatted(args.PropertyConfiguration));
-                
+
                 mapper.Setup(args);
                 args.Result = mapper;
             }
             base.Execute(args);
+        }
+
+        /// <summary>
+        /// Loads a data mapper specifed with the <see cref="DataMapperAttribute"/> if it has been applied to the current property.
+        /// </summary>
+        private AbstractDataMapper LoadFromDataMapperAttribute(DataMapperResolverArgs args)
+        {
+            var propertyInfo = args.PropertyConfiguration.PropertyInfo;
+
+            AbstractDataMapper mapper;
+            if (AttributeMappers.TryGetValue(propertyInfo, out mapper))
+                return mapper;
+
+            var mapperType = propertyInfo.GetCustomAttribute<DataMapperAttribute>()?.DataMapperType;
+
+            if (mapperType == null)
+            {
+                AttributeMappers.Add(propertyInfo, null);
+                return null;
+            }
+
+            var isAbstractDataMapper = typeof (AbstractDataMapper).IsAssignableFrom(mapperType);
+            if (!isAbstractDataMapper)
+            {
+                throw new MapperException(
+                    "Specified data mapper {0} does not inherit from AbstractDataMapper. {1}".Formatted(mapperType.FullName, args.PropertyConfiguration));
+            }
+
+            // Look through registered mappers first
+            mapper = args.DataMappers.FirstOrDefault(x => x.GetType() == mapperType);
+
+            if (mapper == null)
+            {
+                // Create new instance using the default constructor
+                var constructor = mapperType.GetConstructor(Type.EmptyTypes);
+                if (constructor == null)
+                {
+                    throw new MapperException(
+                        "Specified data mapper {0} does not have a default constructor. {1}".Formatted(mapperType.FullName, args.PropertyConfiguration));
+                }
+
+                mapper = (AbstractDataMapper) Activator.CreateInstance(mapperType);
+            }
+
+            AttributeMappers.Add(propertyInfo, mapper);
+
+            return mapper;
         }
     }
 }

--- a/Source/Glass.Mapper/Pipelines/DataMapperResolver/Tasks/DataMapperStandardResolverTask.cs
+++ b/Source/Glass.Mapper/Pipelines/DataMapperResolver/Tasks/DataMapperStandardResolverTask.cs
@@ -100,6 +100,12 @@ namespace Glass.Mapper.Pipelines.DataMapperResolver.Tasks
                 mapper = (AbstractDataMapper) Activator.CreateInstance(mapperType);
             }
 
+            if (!mapper.CanHandle(args.PropertyConfiguration, args.Context))
+            {
+                throw new MapperException(
+                    "Specified data mapper {0} cannot handle this property. {1}".Formatted(mapperType.FullName, args.PropertyConfiguration));
+            }
+
             AttributeMappers.Add(propertyInfo, mapper);
 
             return mapper;

--- a/Tests/Unit Tests/Glass.Mapper.Tests/Glass.Mapper.Tests.csproj
+++ b/Tests/Unit Tests/Glass.Mapper.Tests/Glass.Mapper.Tests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="IoC\AbstractConfigFactoryFixture.cs" />
     <Compile Include="Pipelines\ConfigurationResolver\Tasks\OnDemandResolver\ConfigurationOnDemandResolverTaskFixture.cs" />
     <Compile Include="Pipelines\ConfigurationResolver\Tasks\StandardResolver\ConfigurationStandardResolverTaskFixture.cs" />
+    <Compile Include="Pipelines\DataMapperResolver\DataMapperStandardResolverTaskFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateConcrete\LazyObjectInterceptorFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateInterface\CreateInterfaceTaskFixture.cs" />
     <Compile Include="Pipelines\ObjectConstruction\Tasks\CreateInterface\InterfacePropertyInterceptorFixture.cs" />

--- a/Tests/Unit Tests/Glass.Mapper.Tests/Pipelines/DataMapperResolver/DataMapperStandardResolverTaskFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Tests/Pipelines/DataMapperResolver/DataMapperStandardResolverTaskFixture.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Glass.Mapper.Configuration;
+using Glass.Mapper.Configuration.Attributes;
+using Glass.Mapper.Pipelines.DataMapperResolver;
+using Glass.Mapper.Pipelines.DataMapperResolver.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Glass.Mapper.Tests.Pipelines.DataMapperResolver
+{
+    [TestFixture]
+    public class DataMapperStandardResolverTaskFixture
+    {
+        private DataMapperStandardResolverTask _task;
+
+        [SetUp]
+        public void Setup()
+        {
+            _task = new DataMapperStandardResolverTask();
+        }
+
+        #region Method - Execute
+
+        [Test]
+        public void Execute_InvokesMapperSetup()
+        {
+            //Assign
+            var configuration = Substitute.For<AbstractPropertyConfiguration>();
+            configuration.PropertyInfo = typeof (StubClass).GetProperty("NoAttributeProperty");
+
+            var mapper = Substitute.For<AbstractDataMapper>();
+            mapper.CanHandle(configuration, null).Returns(true);
+
+            var args = new DataMapperResolverArgs(null, configuration);
+            args.DataMappers = new List<AbstractDataMapper> { mapper };
+
+            //Act
+            _task.Execute(args);
+
+            //Assert
+            mapper.Received().Setup(args);
+        }
+
+        [Test]
+        public void Execute_NoDataMapperAttribute_SetsResultToMatchingRegisteredMapper()
+        {
+            //Assign
+            var configuration = Substitute.For<AbstractPropertyConfiguration>();
+            configuration.PropertyInfo = typeof (StubClass).GetProperty("NoAttributeProperty");
+
+            var mapper = Substitute.For<AbstractDataMapper>();
+            mapper.CanHandle(configuration, null).Returns(true);
+
+            var args = new DataMapperResolverArgs(null, configuration);
+            args.DataMappers = new List<AbstractDataMapper> { mapper };
+
+            //Act
+            _task.Execute(args);
+
+            //Assert
+            Assert.IsNotNull(args.Result);
+            Assert.AreEqual(mapper, args.Result);
+        }
+
+        [Test]
+        public void Execute_NoDataMapperAttribute_NoMatchingMapper_ThrowsMapperException()
+        {
+            //Assign
+            var configuration = Substitute.For<AbstractPropertyConfiguration>();
+            configuration.PropertyInfo = typeof (StubClass).GetProperty("NoAttributeProperty");
+
+            var args = new DataMapperResolverArgs(null, configuration);
+            args.DataMappers = Enumerable.Empty<AbstractDataMapper>();
+
+            //Act
+            Assert.Throws<MapperException>(() => _task.Execute(args));
+
+            //Assert
+        }
+
+        [Test]
+        public void Execute_DataMapperAttribute_SetsResultToSpecifiedMapper()
+        {
+            //Assign
+            var configuration = Substitute.For<AbstractPropertyConfiguration>();
+            configuration.PropertyInfo = typeof (StubClass).GetProperty("StubMapperProperty");
+
+            var args = new DataMapperResolverArgs(null, configuration);
+            args.DataMappers = Enumerable.Empty<AbstractDataMapper>();
+
+            //Act
+            _task.Execute(args);
+
+            //Assert
+            Assert.IsNotNull(args.Result);
+            Assert.IsTrue(args.Result.GetType() == typeof(StubMapper));
+        }
+
+        [Test]
+        public void Execute_DataMapperAttribute_SetsResultToMatchingRegisteredMapper()
+        {
+            //Assign
+            var configuration = Substitute.For<AbstractPropertyConfiguration>();
+            configuration.PropertyInfo = typeof (StubClass).GetProperty("StubMapperProperty");
+
+            var mapper = new StubMapper();
+            var args = new DataMapperResolverArgs(null, configuration);
+            args.DataMappers = new List<AbstractDataMapper> {mapper};
+
+            //Act
+            _task.Execute(args);
+
+            //Assert
+            Assert.IsNotNull(args.Result);
+            Assert.AreEqual(mapper, args.Result);
+        }
+
+        [Test]
+        public void Execute_DataMapperAttribute_ResusesMapperInstance()
+        {
+            //Assign
+            var configuration = Substitute.For<AbstractPropertyConfiguration>();
+            configuration.PropertyInfo = typeof (StubClass).GetProperty("StubMapperProperty");
+
+            var args = new DataMapperResolverArgs(null, configuration);
+            args.DataMappers = Enumerable.Empty<AbstractDataMapper>();
+
+            var args2 = new DataMapperResolverArgs(null, configuration);
+            args2.DataMappers = Enumerable.Empty<AbstractDataMapper>();
+
+            //Act
+            _task.Execute(args);
+            _task.Execute(args2);
+
+            //Assert
+            Assert.IsNotNull(args.Result);
+            Assert.IsNotNull(args2.Result);
+            Assert.AreEqual(args.Result, args2.Result);
+        }
+
+        [Test]
+        public void Execute_DataMapperAttribute_CannotHandle_ThrowsMapperException()
+        {
+            //Assign
+            var configuration = Substitute.For<AbstractPropertyConfiguration>();
+            configuration.PropertyInfo = typeof (StubClass).GetProperty("CannotHandleProperty");
+
+            var args = new DataMapperResolverArgs(null, configuration);
+            args.DataMappers = Enumerable.Empty<AbstractDataMapper>();
+
+            //Act
+            Assert.Throws<MapperException>(() => _task.Execute(args));
+
+            //Assert
+        }
+
+        [Test]
+        public void Execute_DataMapperAttribute_MapperMissingConstructor_ThrowsMapperException()
+        {
+            //Assign
+            var configuration = Substitute.For<AbstractPropertyConfiguration>();
+            configuration.PropertyInfo = typeof (StubClass).GetProperty("MissingConstructorStubMapperProperty");
+
+            var args = new DataMapperResolverArgs(null, configuration);
+            args.DataMappers = Enumerable.Empty<AbstractDataMapper>();
+
+            //Act
+            Assert.Throws<MapperException>(() => _task.Execute(args));
+
+            //Assert
+        }
+
+        [Test]
+        public void Execute_DataMapperAttribute_InvalidType_ThrowsMapperException()
+        {
+            //Assign
+            var configuration = Substitute.For<AbstractPropertyConfiguration>();
+            configuration.PropertyInfo = typeof (StubClass).GetProperty("InvalidMapperTypeProperty");
+
+            var args = new DataMapperResolverArgs(null, configuration);
+            args.DataMappers = Enumerable.Empty<AbstractDataMapper>();
+
+            //Act
+            Assert.Throws<MapperException>(() => _task.Execute(args));
+
+            //Assert
+        }
+
+        #endregion
+
+        #region Stubs
+
+        public class StubClass
+        {
+            [DataMapper(typeof(StubMapper))]
+            public string StubMapperProperty { get; set; }
+
+            [DataMapper(typeof(StubMapperCannotHandle))]
+            public string CannotHandleProperty { get; set; }
+
+            [DataMapper(typeof(MissingConstructorStubMapper))]
+            public string MissingConstructorStubMapperProperty { get; set; }
+
+            [DataMapper(typeof(object))]
+            public string InvalidMapperTypeProperty { get; set; }
+
+            public string NoAttributeProperty { get; set; }
+        }
+
+        public class MissingConstructorStubMapper : AbstractDataMapper
+        {
+            public MissingConstructorStubMapper(object obj)
+            {
+            }
+
+            public override void MapToCms(AbstractDataMappingContext mappingContext)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override object MapToProperty(AbstractDataMappingContext mappingContext)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool CanHandle(AbstractPropertyConfiguration configuration, Context context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class StubMapper : AbstractDataMapper
+        {
+            public AbstractDataMappingContext MappingContext { get; set; }
+
+            public override void MapToCms(AbstractDataMappingContext mappingContext)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override object MapToProperty(AbstractDataMappingContext mappingContext)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool CanHandle(AbstractPropertyConfiguration configuration, Context context)
+            {
+                return true;
+            }
+        }
+
+        public class StubMapperCannotHandle : StubMapper
+        {
+            public override bool CanHandle(AbstractPropertyConfiguration configuration, Context context)
+            {
+                return false;
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This adds the ability to control the data mapper used for specific properties using attribute configuration. This is useful if writing a library dependent on Glass but where you can't make sure the client loads your fluent configuration maps.

```C#
[DataMapper(typeof (MyDataMapper))]
[SitecoreField("MyField")]
public MyCustomType MyField { get; set;} 
```

If the attribute is not specified it uses the default logic as before. 

The attribute lookup and potential data mapper instantiation is cached per property so it's only done the first time.

I've added unit tests as well which should cover most if not all cases.