### PR TITLE
Changed it so that a type is only registered if it has not already be…

### DIFF
--- a/Source/Glass.Mapper/Pipelines/ObjectConstruction/Tasks/Ioc/IocTaskBase.cs
+++ b/Source/Glass.Mapper/Pipelines/ObjectConstruction/Tasks/Ioc/IocTaskBase.cs
@@ -42,11 +42,11 @@ namespace Glass.Mapper.Pipelines.ObjectConstruction.Tasks.Ioc
                 {
                     //check to see if the type is registered with the SimpleInjector container
                     //if it isn't added it
-                    if (IsRegistered(configuration.Type))
+                    if (!IsRegistered(configuration.Type))
                     {
                         lock (_lock)
                         {
-                            if (IsRegistered(configuration.Type))
+                            if (!IsRegistered(configuration.Type))
                             {
                                 Register(configuration.Type);
                             }


### PR DESCRIPTION
I noticed in the IocTaskBase that there are two virtual methods, IsRegistered and Register.  In the comments it says to check to see if the type is registered and if not register it.  The logic was actually only attempting to register the type if it was already registered.  This pull request was an attempt to correct this. 