### PR TITLE
Update GetModelFromView.cs

### DIFF
--- a/Source/Glass.Mapper.Sc.Mvc/Pipelines/Response/GetModelFromView.cs
+++ b/Source/Glass.Mapper.Sc.Mvc/Pipelines/Response/GetModelFromView.cs
@@ -121,7 +121,7 @@ namespace Glass.Mapper.Sc.Pipelines.Response
             }
             finally
             {
-                Sitecore.Diagnostics.Log.Info("GetModelFromView {0} {1}".Formatted(watch.ElapsedMilliseconds, args.Rendering.RenderingItem.ID), this);
+                Sitecore.Diagnostics.Log.Debug("GetModelFromView {0} {1}".Formatted(watch.ElapsedMilliseconds, args.Rendering.RenderingItem.ID), this);
             }
         }
 


### PR DESCRIPTION
Changed line 124 to log in debug mode, instead of Info mode.

This kind of information should only be displayed in Debug mode.  

Showing it in Info mode results in a ton of extraneous info when reviewing logs.