### PR TITLE
Fixed an ArgumentNullException in the NetMemoryCacheManager when adding a `null` value.

### DIFF
--- a/Source/Glass.Mapper/Caching/NetMemoryCacheManager.cs
+++ b/Source/Glass.Mapper/Caching/NetMemoryCacheManager.cs
@@ -4,14 +4,18 @@ using System.Threading;
 
 namespace Glass.Mapper.Caching
 {
+    /// <summary>
+    /// A cache manager implementation based on .NET memory cache.
+    /// </summary>
     public class NetMemoryCacheManager : ICacheManager
     {
         private static MemoryCache _memoryCache = new MemoryCache(CacheName);
 
         private const string CacheName = "Glass.Mapper";
 
-        //Absolute time in second
+        // Absolute time in seconds
         public int AbsoluteExpiry { get; set; }
+        
         /// <summary>
         /// Sliding time in seconds
         /// </summary>
@@ -22,11 +26,8 @@ namespace Glass.Mapper.Caching
         /// </summary>
         public NetMemoryCacheManager()
         {
-
-            //20 minute default
-            SlidingExpiry = 60*20;
+            SlidingExpiry = 60 * 20;
         }
-
 
         public object this[string key]
         {
@@ -35,7 +36,7 @@ namespace Glass.Mapper.Caching
         }
 
         /// <summary>
-        /// Destroys and recreates the cache
+        /// Destroys and recreates the cache.
         /// </summary>
         public void ClearCache()
         {
@@ -57,16 +58,19 @@ namespace Glass.Mapper.Caching
                 _memoryCache.Remove(key);
             }
 
-            CacheItemPolicy cacheItemPolicy = new CacheItemPolicy();
-            if (AbsoluteExpiry > 0)
+            if (value != null)
             {
-                cacheItemPolicy.AbsoluteExpiration = DateTime.Now.AddSeconds(AbsoluteExpiry);
-                _memoryCache.Add(key, value, cacheItemPolicy);
-            }
-            else
-            {
-                cacheItemPolicy.SlidingExpiration = new TimeSpan(0, 0, SlidingExpiry);
-                _memoryCache.Add(key, value, cacheItemPolicy);
+                CacheItemPolicy cacheItemPolicy = new CacheItemPolicy();
+                if (AbsoluteExpiry > 0)
+                {
+                    cacheItemPolicy.AbsoluteExpiration = DateTime.Now.AddSeconds(AbsoluteExpiry);
+                    _memoryCache.Add(key, value, cacheItemPolicy);
+                }
+                else
+                {
+                    cacheItemPolicy.SlidingExpiration = new TimeSpan(0, 0, SlidingExpiry);
+                    _memoryCache.Add(key, value, cacheItemPolicy);
+                }
             }
         }
 
@@ -79,9 +83,9 @@ namespace Glass.Mapper.Caching
         {
             try
             {
-                return (T) _memoryCache[key];
+                return (T)_memoryCache[key];
             }
-            catch (Exception ex)
+            catch
             {
                 return default(T);
             }


### PR DESCRIPTION
The following exception was thrown in my application:

``` csharp
[ArgumentNullException: Value cannot be null.
Parameter name: value]
   System.Runtime.Caching.MemoryCacheEntry..ctor(String key, Object value, DateTimeOffset absExp, TimeSpan slidingExp, CacheItemPriority priority, Collection`1 dependencies, CacheEntryRemovedCallback removedCallback, MemoryCache cache) +78387
   System.Runtime.Caching.MemoryCache.AddOrGetExistingInternal(String key, Object value, CacheItemPolicy policy) +563
   System.Runtime.Caching.ObjectCache.Add(String key, Object value, CacheItemPolicy policy, String regionName) +25
   Glass.Mapper.Caching.NetMemoryCacheManager.AddOrUpdate(String key, T value) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\Caching\NetMemoryCacheManager.cs:71
   Glass.Mapper.Pipelines.ObjectConstruction.Tasks.CacheCheck.CacheCheckTask.Execute(ObjectConstructionArgs args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\Pipelines\ObjectConstruction\Tasks\CacheCheck\CacheCheckTask.cs:50
   Glass.Mapper.Pipelines.<>c__DisplayClass8.<.ctor>b__1(T args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\Pipelines\AbstractPipelineRunner.cs:74
   Glass.Mapper.Pipelines.AbstractPipelineTask`1.Next(T args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\Pipelines\AbstractPipelineTask.cs:53
   Glass.Mapper.Sc.Pipelines.ObjectConstruction.SitecoreItemTask.Execute(ObjectConstructionArgs args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper.Sc\Pipelines\ObjectConstruction\SitecoreItemTask.cs:24
   Glass.Mapper.Pipelines.<>c__DisplayClass8.<.ctor>b__1(T args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\Pipelines\AbstractPipelineRunner.cs:74
   Glass.Mapper.Pipelines.AbstractPipelineTask`1.Next(T args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\Pipelines\AbstractPipelineTask.cs:53
   Glass.Mapper.Sc.Pipelines.ObjectConstruction.CreateDynamicTask.Execute(ObjectConstructionArgs args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper.Sc\Pipelines\ObjectConstruction\CreateDynamicTask.cs:59
   Glass.Mapper.Pipelines.<>c__DisplayClass8.<.ctor>b__1(T args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\Pipelines\AbstractPipelineRunner.cs:74
   Glass.Mapper.Pipelines.AbstractPipelineTask`1.Next(T args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\Pipelines\AbstractPipelineTask.cs:53
   Glass.Mapper.Pipelines.ObjectConstruction.Tasks.DepthCheck.ModelDepthCheck.Execute(ObjectConstructionArgs args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\Pipelines\ObjectConstruction\Tasks\DepthCheck\ModelDepthCheck.cs:18
   Glass.Mapper.Pipelines.AbstractPipelineRunner`2.Run(T args) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\Pipelines\AbstractPipelineRunner.cs:97
   Glass.Mapper.AbstractService.InstantiateObject(AbstractTypeCreationContext abstractTypeCreationContext) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper\AbstractService.cs:160
   Glass.Mapper.Sc.SitecoreService.CreateType(Type type, Item item, Boolean isLazy, Boolean inferType, Dictionary`2 parameters, Object[] constructorParameters) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper.Sc\SitecoreService.cs:506
   Glass.Mapper.Sc.SitecoreService.CreateType(Item item, Boolean isLazy, Boolean inferType, Object[] constructorParameters) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper.Sc\SitecoreService.cs:484
   Glass.Mapper.Sc.SitecoreService.CreateType(Item item, Boolean isLazy, Boolean inferType) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper.Sc\SitecoreService.cs:362
   Glass.Mapper.Sc.AbstractSitecoreContext.GetCurrentItem(Boolean isLazy, Boolean inferType) in c:\TeamCity\buildAgent\work\8567e2ba106d3992\Source\Glass.Mapper.Sc\AbstractSitecoreContext.cs:165
```

Adding a null check solves the error.