### PR TITLE
Dispose memory cache

### DIFF
--- a/Source/Glass.Mapper/Caching/NetMemoryCacheManager.cs
+++ b/Source/Glass.Mapper/Caching/NetMemoryCacheManager.cs
@@ -40,8 +40,10 @@ namespace Glass.Mapper.Caching
         public void ClearCache()
         {
             // destroy and recreate the cache
+            var cache = _memoryCache;
             var newMemoryCache = new MemoryCache(CacheName);
             Interlocked.Exchange(ref _memoryCache, newMemoryCache);
+            cache.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
The memory cache should get properly disposed. Otherwise undisposed timers will pile up, which can cause severe performance issues if the caches are cleared frequently.