### PR TITLE
#324 Adds class property mapper for mailto LinkType

### DIFF
--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldLinkMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldLinkMapper.cs
@@ -109,6 +109,7 @@ namespace Glass.Mapper.Sc.DataMappers
                     link.Type = LinkType.External;
                     break;
                 case "mailto":
+                    link.Class = linkField.GetAttribute("style");
                     link.Url = linkField.Url;
                     link.Type = LinkType.MailTo;
                     break;


### PR DESCRIPTION
Fixes issue #324 with style attribute not mapping to the Class property of the Sitecore Link type