### PR TITLE
- Fixed missing textwriter in glasseditframe if only a editframe is p…

### DIFF
--- a/Source/Glass.Mapper.Sc.Mvc/Web/Mvc/HtmlHelperExtensions.cs
+++ b/Source/Glass.Mapper.Sc.Mvc/Web/Mvc/HtmlHelperExtensions.cs
@@ -161,9 +161,9 @@ namespace Glass.Mapper.Sc.Web.Mvc
         /// <returns></returns>
         public static GlassEditFrame BeginEditFrame(this HtmlHelper htmlHelper, EditFrame editFrame)
         {
-            var writter = new HtmlTextWriter(htmlHelper.ViewContext.Writer);
-            editFrame.RenderFirstPart(writter);
-            return new GlassEditFrame(editFrame);
+            var glassEditFrame = new GlassEditFrame(editFrame, htmlHelper.ViewContext.Writer);
+            glassEditFrame.RenderFirstPart();
+            return glassEditFrame;
         }
 
         public static GlassHtmlMvc<T> Glass<T>(this HtmlHelper<T> htmlHelper)

--- a/Source/Glass.Mapper.Sc/Web/Ui/GlassEditFrame.cs
+++ b/Source/Glass.Mapper.Sc/Web/Ui/GlassEditFrame.cs
@@ -38,9 +38,11 @@ namespace Glass.Mapper.Sc.Web.Ui
         /// Initializes a new instance of the <see cref="GlassEditFrame"/> class.
         /// </summary>
         /// <param name="frame">The frame.</param>
-        public GlassEditFrame(EditFrame frame)
+        /// <param name="writer">The writer.</param>
+        public GlassEditFrame(EditFrame frame, TextWriter writer)
         {
             _frame = frame;
+            _writer = new HtmlTextWriter(writer);
         }
 
         /// <summary>

--- a/Source/Glass.Mapper.Sc/Web/Ui/GlassEditFrame.cs
+++ b/Source/Glass.Mapper.Sc/Web/Ui/GlassEditFrame.cs
@@ -31,7 +31,6 @@ namespace Glass.Mapper.Sc.Web.Ui
             _frame.Buttons = buttons;
             _frame.Title = title;
             _writer = new HtmlTextWriter(writer);
-
         }
 
         /// <summary>
@@ -66,7 +65,7 @@ namespace Glass.Mapper.Sc.Web.Ui
 
     public class GlassNullEditFrame : GlassEditFrame
     {
-        public GlassNullEditFrame() : base(null)
+        public GlassNullEditFrame() : base(null, null)
         {
         }
 


### PR DESCRIPTION
Implementing GlassEditFrame with only an sitecore edit frame cause an null reference exception in the dispose method because the writer is not implemented.

Fixed this issue by implementing a second parameter for the writer.