### PR TITLE
Glass.Mapper.Sc.Utilities: use 'Append' since the string is formatted via an extension method.

### DIFF
--- a/Source/Glass.Mapper.Sc/Utilities.cs
+++ b/Source/Glass.Mapper.Sc/Utilities.cs
@@ -74,7 +74,7 @@ namespace Glass.Mapper.Sc
             StringBuilder sb = new StringBuilder();
             foreach (var pair in attributes)
             {
-                sb.AppendFormat("{0}={2}{1}{2} ".Formatted(pair.Key, pair.Value ??"", quotationMark));
+                sb.Append("{0}={2}{1}{2} ".Formatted(pair.Key, pair.Value ??"", quotationMark));
             }
 
             return sb.ToString();


### PR DESCRIPTION
This solves #272 because like stated in the original issue the string is formatted two times. If `pair.Value` contains the string value "Foo {bar}" this will cause a FormatException because you are calling StringBuilder.AppendFormat with no format arguments.