### PR TITLE
Adding ability to pass in NameValueCollection to the HtmlHelpers dire…

### DIFF
--- a/Source/Glass.Mapper/Utilities.cs
+++ b/Source/Glass.Mapper/Utilities.cs
@@ -218,6 +218,11 @@ namespace Glass.Mapper
         public static NameValueCollection GetPropertiesCollection(object target, bool lowerCaseName = false,
             bool underscoreForHyphens = true)
         {
+            if (target != null && target is NameValueCollection)
+            {
+                return (NameValueCollection)target;
+            }
+
             NameValueCollection nameValues = new NameValueCollection();
             if (target != null)
             {


### PR DESCRIPTION
Adding ability to pass in NameValueCollection to the HtmlHelpers directly
It will make it really easier to extend the Glass Html helpers and make a strongly typed helper, if we can pass in the Some type of dictionary for custom html attribute.