### PR TITLE
Reset TemplateId and EnforceTemplate options for each child

### DIFF
--- a/Source/Glass.Mapper.Sc/LazyItemEnumerable.cs
+++ b/Source/Glass.Mapper.Sc/LazyItemEnumerable.cs
@@ -69,15 +69,15 @@ namespace Glass.Mapper.Sc
 
             var options = new GetItemByItemOptions();
             options.Copy(_options);
-            //we have to copy these properties to the sub item because
-            //normally they are not applied to the whole graph
-            options.TemplateId = _options.TemplateId;
-            options.EnforceTemplate = _options.EnforceTemplate;
-
 
             foreach (Item child in items)
             {
                 options.Item = child;
+                //we have to copy these properties to the sub item because
+                //normally they are not applied to the whole graph
+                options.TemplateId = _options.TemplateId;
+                options.EnforceTemplate = _options.EnforceTemplate;
+
                 var obj = _service.GetItem(options) as T;
 
                 if (obj == null)

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/Glass.Mapper.Sc.FakeDb.csproj
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/Glass.Mapper.Sc.FakeDb.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Issues\Issue299\Issue299Fixture.cs" />
     <Compile Include="Issues\Issue311\Issue311Fixture.cs" />
     <Compile Include="Issues\Issue370\Issue370Fixture.cs" />
+    <Compile Include="LazyItemEnumerableFixture.cs" />
     <Compile Include="LazyLoadingFixture.cs" />
     <Compile Include="MediaUrlOptionsResolverFixture.cs" />
     <Compile Include="MiscFixture.cs" />

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/LazyItemEnumerableFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/LazyItemEnumerableFixture.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Generic;
+using Glass.Mapper.Sc.Configuration;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using NUnit.Framework;
+using Sitecore.Data;
+using Sitecore.FakeDb;
+
+namespace Glass.Mapper.Sc.FakeDb
+{
+    [TestFixture]
+    public class LazyItemEnumerableFixture
+    {
+        [Test]
+        public void ProcessItems_ResetsOptionsTemplateIdAndEnforceTemplateForEachChild()
+        {
+            //Assign
+            using (var database = new Db
+            {
+                new DbItem("TestItem")
+                {
+                    new DbItem("Child1"),
+                    new DbItem("Child2"),
+                    new DbItem("Child3")
+                }
+            })
+            {
+                var getItemOptions = new GetItemsByFuncOptions
+                {
+                    ItemsFunc = _ => database.GetItem("/sitecore/content/TestItem").Children.ToArray(),
+                    TemplateId = null,
+                    EnforceTemplate = SitecoreEnforceTemplate.Default
+                };
+
+                var receivedOptions = new List<GetItemByItemOptions>();
+                var receivedTemplateIds = new List<ID>();
+                var receivedEnforceTemplate = new List<SitecoreEnforceTemplate>();
+
+                var service = Substitute.For<ISitecoreService>();
+                service.GetItem(Arg.Any<GetItemByItemOptions>())
+                    .ReturnsNull()
+                    .AndDoes(x =>
+                    {
+                        var options = x.Arg<GetItemByItemOptions>();
+                        receivedOptions.Add(options);
+                        receivedTemplateIds.Add(options.TemplateId);
+                        receivedEnforceTemplate.Add(options.EnforceTemplate);
+
+                        // Emulate ConfigureOptionsForTypeTask overwriting TemplateId and EnforceTemplate
+                        options.TemplateId = ID.NewID;
+                        options.EnforceTemplate = SitecoreEnforceTemplate.TemplateAndBase;
+                    });
+
+                var lazyItemEnumerable = new LazyItemEnumerable<Stub>(getItemOptions, service, new LazyLoadingHelper());
+
+                //Act
+                lazyItemEnumerable.ProcessItems();
+
+                //Assert
+                Assert.AreEqual(3, receivedOptions.Count);
+                foreach (var options in receivedOptions)
+                {
+                    // Received options should have been modified from original values
+                    Assert.IsNotNull(options.TemplateId);
+                    Assert.AreEqual(options.EnforceTemplate, SitecoreEnforceTemplate.TemplateAndBase);
+                }
+
+                foreach (var id in receivedTemplateIds)
+                {
+                    // Received values should be original value
+                    Assert.IsNull(id);
+                }
+
+                foreach (var enforceTemplate in receivedEnforceTemplate)
+                {
+                    // Received values should be original value
+                    Assert.AreEqual(enforceTemplate, SitecoreEnforceTemplate.Default);
+                }
+            }
+        }
+
+        public class Stub
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
They could end up being modified by the type configurations (through the `ConfigureOptionsForType` task) if set to default values.

Fixes #377 