### PR TITLE
Updated RegexViewTypeResolver resolution to support global::

### DIFF
--- a/Source/Glass.Mapper.Sc.Mvc/Pipelines/Response/RegexViewTypeResolver.cs
+++ b/Source/Glass.Mapper.Sc.Mvc/Pipelines/Response/RegexViewTypeResolver.cs
@@ -18,7 +18,7 @@ namespace Glass.Mapper.Sc.Pipelines.Response
 
 
         public static readonly Regex UsingRegex = new Regex(@"@using\s+(?<namespace>[^\n\s;()]+)");
-        public static readonly Regex ModelRegex = new Regex(@"@model\s+(?<type>[^\n\s;]+)");
+        public static readonly Regex ModelRegex = new Regex(@"@model\s+(global::)?(?<type>[^\n\s;]+)");
         public static readonly Regex InheritsRegex = new Regex("@inherits.*<(?<type>[^>]*)>");
         private static IEnumerable<Assembly> _assemblies;
 

--- a/Tests/Unit Tests/Glass.Mapper.Sc.Mvc.Tests/RegexTypeFinderFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.Mvc.Tests/RegexTypeFinderFixture.cs
@@ -78,6 +78,19 @@ namespace Glass.Mapper.Sc.Mvc.Tests
             //Assert
             Assert.AreEqual(typeof(RegexTypeFinderFixture), result);
         }
+        
+        [Test]
+        public void GetType_GlobalNamespace_ReturnsType()
+        {
+            //Arrange
+            string contents = "@model global::Glass.Mapper.Sc.Mvc.Tests.RegexTypeFinderFixture";
+            var finder = new StubFinder();
+            //Act
+            var result = finder.GetType(contents);
+
+            //Assert
+            Assert.AreEqual(typeof(RegexTypeFinderFixture), result);
+        }
 
         [Test]
         public void GetType_MultiLine_ReturnsType()


### PR DESCRIPTION
Currently if you use global:: in a model it will fail to resolve the type. This resolves this by adding an optional global:: into the regex which allows backwards compatibility.