### PR TITLE
fixed wrong behaviour of ItemVersionCountByRevisionTask with missing language version on item, but existing version on standardvalues

### DIFF
--- a/Source/Glass.Mapper.Sc/Pipelines/ObjectConstruction/ItemVersionCountByRevisionTask.cs
+++ b/Source/Glass.Mapper.Sc/Pipelines/ObjectConstruction/ItemVersionCountByRevisionTask.cs
@@ -14,7 +14,7 @@ namespace Glass.Mapper.Sc.Pipelines.ObjectConstruction
                 && options != null
                 && options.VersionCount 
                 && scContext.Item != null
-                && scContext.Item[FieldIDs.Revision].IsNullOrEmpty())
+                && (scContext.Item.Fields[FieldIDs.Revision].GetValue(false).IsNullOrEmpty()))
             {
 
                 args.Result = null;


### PR DESCRIPTION
the change vom item.Versions.Count to this new implementation is not working like before.
we have found an issue with the following scenario:

> Item A (de-DE)
> has Template B with standardvalues (en; de-DE)
> 
> if you call scContext.Item[FieldIDs.Revision].Value 
> on the english version, you will get the value of the standardvalue, instead of empty/null.

to get around this issue it is possible to call the method GetValue(allowStandardValue = false).
scContext.Item.Fields[FieldIDs.Revision] will always return an object, when calling the index operator with an id (with filename it returns null).

Could you please check and merge this change @mikeedwards83 

Thanks in advance.
