### PR TITLE
Fixed nullreference when no Site is available in the SiteContext when getting fields

### DIFF
--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldStringMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldStringMapper.cs
@@ -77,7 +77,14 @@ namespace Glass.Mapper.Sc.DataMappers
             };
             try
             {
-                using (new SiteContextSwitcher(options.Site))
+                if (options.Site != null)
+                {
+                    using (new SiteContextSwitcher(options.Site))
+                    {
+                        CorePipeline.Run("renderField", renderFieldArgs);
+                    }
+                }
+                else
                 {
                     CorePipeline.Run("renderField", renderFieldArgs);
                 }


### PR DESCRIPTION
Hi,

Within the commit below, a change has been introduced that uses a SiteSwitcher so the url of links can be properly generated.
https://github.com/mikeedwards83/Glass.Mapper/commit/24309df4cbc5b3dc956bbb3502770fc5a0645d94

This is new in Glass5, and causes null reference errors when the Sitecore.Context.Site is null, when the code is executed. I've added a fallback to make sure everything works, because a SiteContext should not be nessecary for all other logic