### PR TITLE
Added fix to resolve datasource when A/B testing with a View Rendering

### DIFF
--- a/Source/Glass.Mapper.Sc.Mvc/Pipelines/Response/GetModelFromView.cs
+++ b/Source/Glass.Mapper.Sc.Mvc/Pipelines/Response/GetModelFromView.cs
@@ -146,6 +146,15 @@ namespace Glass.Mapper.Sc.Pipelines.Response
 
             if (renderingItem.DataSource.HasValue())
             {
+                // Handle A/B testing ItemUri datasource
+                if (renderingItem.DataSource.StartsWith("sitecore://", StringComparison.Ordinal))
+                {
+                    var item = Sitecore.Context.Database.GetItem(DataUri.Parse(renderingItem.DataSource));
+                    var getItemOptions = new GetItemByItemOptions(item);
+                    getItemOptions.Type = modelType;
+                    return mvcContext.SitecoreService.GetItem(getItemOptions);
+                }
+
                 var getOptions = new GetItemByPathOptions();
                 getOptions.Type = modelType;
                 getOptions.Path = renderingItem.DataSource;


### PR DESCRIPTION
This fix corrects the A/B testing in View Renderings.  

There was a previous fix made for similar reports to A/B testing, but that only corrected the issue with Controller Renderings.  

I encountered this issue as I have a custom object construction task to map a custom view model.  I noticed that A/B testing worked fine when Controller Renderings were used, however they broke with View Renderings and the Item was null with GetItemByPathOptions of the datasource in ItemUri format

This should address #433 