### PR TITLE
Upgraded all sitecore librray related to Sitecore 10.4

### DIFF
--- a/CommonSettings.targets
+++ b/CommonSettings.targets
@@ -1,7 +1,27 @@
 <Project>
 	<Choose>
-		<When Condition="'$(Configuration)|$(Platform)' == 'sc103|AnyCPU' Or '$(ScVersion)' == '10.3.0' Or '$(ScVersion)' == '' or
+		<When Condition="'$(Configuration)|$(Platform)' == 'sc104|AnyCPU' Or '$(ScVersion)' == '10.4.0' Or '$(ScVersion)' == '' or
                      '$(ScVersion)' == '*undefined*'">
+			<PropertyGroup>
+				<IncludeContentExtractionDll>true</IncludeContentExtractionDll>
+				<ScFakeDBVersion>3.0.0-alpha1</ScFakeDBVersion>
+				<NSubstituteVersion>4.2.1</NSubstituteVersion>
+				<CastleVersion>4.4.0</CastleVersion>
+				<TargetFramework Condition="'$(TargetFramework)' == '' ">net48</TargetFramework>
+				<AspNetMvcVersion>5.2.4</AspNetMvcVersion>
+				<AspNetRazorWebVersion>3.2.4</AspNetRazorWebVersion>
+				<DebugSymbols>true</DebugSymbols>
+				<DefineConstants>SC104</DefineConstants>
+				<DebugType>full</DebugType>
+				<PlatformTarget>AnyCPU</PlatformTarget>
+				<ErrorReport>prompt</ErrorReport>
+				<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+				<OutputPath>bin\104\</OutputPath>
+				<ScVersion>10.4.0</ScVersion>
+			</PropertyGroup>
+		</When>
+
+		<When Condition="'$(Configuration)|$(Platform)' == 'sc103|AnyCPU' Or '$(ScVersion)' == '10.3.0'">
 			<PropertyGroup>
 				<IncludeContentExtractionDll>true</IncludeContentExtractionDll>
 				<ScFakeDBVersion>3.0.0-alpha1</ScFakeDBVersion>

--- a/Source/Glass.Mapper.Sc.ContentSearch/Glass.Mapper.Sc.ContentSearch.csproj
+++ b/Source/Glass.Mapper.Sc.ContentSearch/Glass.Mapper.Sc.ContentSearch.csproj
@@ -10,7 +10,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-  <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+  <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
+  <TargetFramework>net481</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/Source/Glass.Mapper.Sc.ContentSearch/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/Glass.Mapper.Sc.ContentSearch/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\104\net481\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net481</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Source/Glass.Mapper.Sc.Mvc/Glass.Mapper.Sc.Mvc.csproj
+++ b/Source/Glass.Mapper.Sc.Mvc/Glass.Mapper.Sc.Mvc.csproj
@@ -11,7 +11,7 @@
 	<SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <TargetFrameworkProfile />
     <DocumentationFile>bin\Glass.Mapper.Sc.Mvc.XML</DocumentationFile>
-  <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+  <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
   </PropertyGroup>
 	<PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -21,6 +21,7 @@
 		<NuspecProperties>$(NuspecProperties);version=$(Version)</NuspecProperties>
 		<NuspecProperties>$(NuspecProperties);scVersion=$(PackageScVersion)</NuspecProperties>
 		<NuspecProperties>$(NuspecProperties);netVersion=$(TargetFramework)</NuspecProperties>
+		<TargetFramework>net481</TargetFramework>
 	</PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,7 +34,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/Source/Glass.Mapper.Sc.Mvc/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/Glass.Mapper.Sc.Mvc/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\104\net481\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net481</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Source/Glass.Mapper.Sc.WebForms/Glass.Mapper.Sc.WebForms.csproj
+++ b/Source/Glass.Mapper.Sc.WebForms/Glass.Mapper.Sc.WebForms.csproj
@@ -10,7 +10,7 @@
     <FileAlignment>512</FileAlignment>
 	<SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <DocumentationFile>bin\Glass.Mapper.Sc.WebForms.xml</DocumentationFile>
-    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
   </PropertyGroup>
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
@@ -20,6 +20,7 @@
 		<NuspecProperties>$(NuspecProperties);version=$(Version)</NuspecProperties>
 		<NuspecProperties>$(NuspecProperties);scVersion=$(PackageScVersion)</NuspecProperties>
 		<NuspecProperties>$(NuspecProperties);netVersion=$(TargetFramework)</NuspecProperties>
+		<TargetFramework>net481</TargetFramework>
 	</PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,7 +31,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/Source/Glass.Mapper.Sc.WebForms/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/Glass.Mapper.Sc.WebForms/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\104\net481\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net481</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Source/Glass.Mapper.Sc/Configuration/SitecoreInfoType.cs
+++ b/Source/Glass.Mapper.Sc/Configuration/SitecoreInfoType.cs
@@ -67,7 +67,7 @@ namespace Glass.Mapper.Sc.Configuration
         /// </summary>
         BaseTemplateIds=14,
 
-#if SC81 || SC82 || SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC81 || SC82 || SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
         /// <summary>
         /// Gets  the original language.
         /// </summary>

--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldScWrapperMappers.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreFieldScWrapperMappers.cs
@@ -217,7 +217,7 @@ namespace Glass.Mapper.Sc.DataMappers
         }
     }
 
-#if !SC93 && !SC100 && !SC101 && !SC102 && !SC103 //removed in > SC93
+#if !SC93 && !SC100 && !SC101 && !SC102 && !SC103 && !SC104 //removed in > SC93
 
     public class SitecoreFieldScVersionLinkFieldMapper : SitecoreFieldScFieldBaseMapper<Sitecore.Data.Fields.VersionLinkField>
     {

--- a/Source/Glass.Mapper.Sc/DataMappers/SitecoreInfoMapper.cs
+++ b/Source/Glass.Mapper.Sc/DataMappers/SitecoreInfoMapper.cs
@@ -237,7 +237,7 @@ namespace Glass.Mapper.Sc.DataMappers
                 case SitecoreInfoType.ItemUri:
                     _getValue = (item, getOptions) => new ItemUri(item.ID, item.Language, item.Version, item.Database);
                     break;
-#if (SC82  || SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103) 
+#if (SC82  || SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104) 
                 case SitecoreInfoType.OriginalLanguage:
                     _getValue = (item, getOptions) => item.OriginalLanguage;
                     break;

--- a/Source/Glass.Mapper.Sc/Glass.Mapper.Sc.csproj
+++ b/Source/Glass.Mapper.Sc/Glass.Mapper.Sc.csproj
@@ -14,7 +14,7 @@
     <RestorePackages>true</RestorePackages>
 	<TargetFrameworkProfile />
     <DocumentationFile>bin\Glass.Mapper.Sc.XML</DocumentationFile>
-    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
   </PropertyGroup>
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
@@ -23,6 +23,7 @@
 	    <NuspecFile>$(SolutionDir)/NugetDefinitions/Glass.Mapper.Sc.symbols.nuspec</NuspecFile>
 		<NuspecProperties>$(NuspecProperties);version=$(Version)</NuspecProperties>
 		<NuspecProperties>$(NuspecProperties);scVersion=$(PackageScVersion)</NuspecProperties>
+		<TargetFramework>net481</TargetFramework>
 	</PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,7 +35,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/Source/Glass.Mapper.Sc/GlassHtml.cs
+++ b/Source/Glass.Mapper.Sc/GlassHtml.cs
@@ -503,7 +503,7 @@ namespace Glass.Mapper.Sc
             AttributeCheck(attributes, "title", title);
             AttributeCheck(attributes, "style", link.Style);
 
-#if  SC90 || SC91|| SC92 || SC93 || SC100 || SC101 || SC102 || SC103
+#if  SC90 || SC91|| SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
             if (attributes["target"] == "_blank" && Settings.ProtectExternalLinksWithBlankTarget)
             {

--- a/Source/Glass.Mapper.Sc/Pipelines/GetChromeData/EditFrameBuilder.cs
+++ b/Source/Glass.Mapper.Sc/Pipelines/GetChromeData/EditFrameBuilder.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 using Sitecore;
-#if SC93 || SC100 || SC101 || SC102 || SC103
+#if SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 using Sitecore.Abstractions;
 #endif
 using Sitecore.Configuration;
@@ -38,7 +38,7 @@ namespace Glass.Mapper.Sc.Pipelines.GetChromeData
 
         private readonly Regex _titleRegex = new Regex("<title>(?<title>([^<]*))<title>");
 
-#if SC93 || SC100 || SC101 || SC102 || SC103
+#if SC93 || SC100 || SC101 || SC102 || SC103 || SC104
         public EditFrameBuilder(BaseClient client) : base(client)
         {
 

--- a/Source/Glass.Mapper.Sc/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/Glass.Mapper.Sc/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\104\net481\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net481</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Source/Glass.Mapper.Sc/SitecoreVersionAbstractions.cs
+++ b/Source/Glass.Mapper.Sc/SitecoreVersionAbstractions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#if SC90 || SC91  || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91  || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 using Sitecore.Abstractions;
 using Sitecore.DependencyInjection;
 #endif
@@ -18,12 +18,12 @@ namespace Glass.Mapper.Sc
 {
     public class SitecoreVersionAbstractions
     {
-#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
         internal static LazyResetable<BaseMediaManager> MediaManager = ServiceLocator.GetRequiredResetableService<BaseMediaManager>();
         internal static LazyResetable<BaseLinkManager> LinkManager = ServiceLocator.GetRequiredResetableService<BaseLinkManager>();
 
-
+        internal static string renderingParamKey = "renderingParameters";
         public static string GetMediaUrl(MediaItem media, MediaUrlOptions mediaUrlOptions)
         {
             return MediaManager.Value.GetMediaUrl(media, mediaUrlOptions);
@@ -35,6 +35,13 @@ namespace Glass.Mapper.Sc
 
         public static string GetItemUrl(Item item, UrlOptions urlOptions)
         {
+            //Added check for when rendering paramater request comes as Sitecore.Links.UrlBuilders.Helpers.ItemPathBuilder.GetRelativePath
+            //implementation has been changed in Sitecore 10.4
+            //below changes will return only url when requested for a item 
+            if (item.Name == renderingParamKey)
+            {
+                return "/renderingparameters";
+            }
             return LinkManager.Value.GetItemUrl(item, urlOptions);
         }
 

--- a/Source/Glass.Mapper.Sc/Utilities.cs
+++ b/Source/Glass.Mapper.Sc/Utilities.cs
@@ -23,7 +23,7 @@ namespace Glass.Mapper.Sc
         {
             get
             {
-#if SC82 || SC90 || SC91  || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC82 || SC90 || SC91  || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
                 return Sitecore.Context.PageMode.IsExperienceEditor;
 #else
                 return Sitecore.Context.PageMode.IsPageEditor;
@@ -37,7 +37,7 @@ namespace Glass.Mapper.Sc
 
         internal static Func<bool> GetIsPageEditorEditing = () =>
         {
-#if SC82 || SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC82 || SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
             return Sitecore.Context.PageMode.IsExperienceEditorEditing;
 #else
             return Sitecore.Context.PageMode.IsPageEditorEditing;

--- a/Source/Glass.Mapper/Glass.Mapper.csproj
+++ b/Source/Glass.Mapper/Glass.Mapper.csproj
@@ -14,7 +14,7 @@
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
     <DocumentationFile>bin\Glass.Mapper.XML</DocumentationFile>
-    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
   </PropertyGroup>
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
@@ -37,7 +37,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
 	
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -95,6 +95,7 @@
 
   <PropertyGroup>
     <SHFBROOT>C:\Program Files (x86)\EWSoftware\Sandcastle Help File Builder</SHFBROOT>
+    <TargetFramework>net481</TargetFramework>
   </PropertyGroup>
   <!-- Target Name="AfterBuild">
     < Build source code docs >

--- a/Source/Glass.Mapper/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/Glass.Mapper/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\104\net481\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net481</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb.ThirdParty/Glass.Mapper.Sc.FakeDb.ThirdParty.csproj
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb.ThirdParty/Glass.Mapper.Sc.FakeDb.ThirdParty.csproj
@@ -9,7 +9,8 @@
     <AssemblyName>Glass.Mapper.Sc.FakeDb.ThirdParty</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <RestorePackages>true</RestorePackages>
-  <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+  <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
+  <TargetFramework>net481</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -21,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -57,7 +58,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Sitecore.Kernel" Version="$(ScVersion)" />
-		<PackageReference Include="Sitecore.Nexus" Version="$(ScVersion)" Condition="'$(ScVersion)' != '10.2.0' and '$(ScVersion)' != '10.3.0'" />
 		<PackageReference Include="Sitecore.Analytics" Version="$(ScVersion)" />
 		<PackageReference Include="Sitecore.Client" Version="$(ScVersion)" />
 	</ItemGroup>

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/DataMappers/SitecoreFieldFileMapperFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/DataMappers/SitecoreFieldFileMapperFixture.cs
@@ -7,7 +7,7 @@ using Sitecore.Data;
 using Sitecore.FakeDb;
 using Sitecore.Resources.Media;
 
-#if SC90 || SC91  || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91  || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 using Sitecore.Abstractions;
 using Sitecore.DependencyInjection;
 #endif
@@ -42,7 +42,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
             {
 
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 
@@ -178,7 +178,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
 
 
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/DataMappers/SitecoreFieldImageMapperFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/DataMappers/SitecoreFieldImageMapperFixture.cs
@@ -14,7 +14,7 @@ using Sitecore.FakeDb;
 using Sitecore.Resources.Media;
 using Image = Glass.Mapper.Sc.Fields.Image;
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 using Sitecore.Abstractions;
 using Sitecore.DependencyInjection;
 #endif
@@ -56,7 +56,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
             {
 
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 
@@ -121,7 +121,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
             })
             {
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 
@@ -324,7 +324,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
 
 
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/DataMappers/SitecoreFieldLinkMapperFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/DataMappers/SitecoreFieldLinkMapperFixture.cs
@@ -8,7 +8,7 @@ using Sitecore.Data;
 using Sitecore.FakeDb;
 using Sitecore.Links;
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 using Sitecore.Abstractions;
 using Sitecore.DependencyInjection;
 #endif
@@ -258,7 +258,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
                     field.Value = fieldValue;
                 }
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var linkProvider = Substitute.For<BaseLinkManager>();
                 linkProvider
@@ -335,7 +335,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
                 }
 
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var linkProvider = Substitute.For<BaseLinkManager>();
                 linkProvider
@@ -411,7 +411,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
                     field.Value = fieldValue;
                 }
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var linkProvider = Substitute.For<BaseLinkManager>();
                 linkProvider
@@ -543,7 +543,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
                 }
 
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var linkProvider = Substitute.For<BaseLinkManager>();
                 linkProvider
@@ -670,7 +670,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
                 }
 
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 
@@ -1001,7 +1001,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
             {
                 var mapper = new SitecoreFieldLinkMapper(new FakeUrlOptionsResolver());
 
-#if SC93 || SC100 || SC101 || SC102 || SC103
+#if SC93 || SC100 || SC101 || SC102 || SC103 || SC104
                 var expected =
                     "<link target=\"testTarget\" title=\"test alternative\" querystring=\"q%3ds\" linktype=\"internal\" id=\"{0}\" anchor=\"testAnchor\" url=\"/en/sitecore/content/Target\" class=\"testClass\" text=\"Test description\" />"
                         .Formatted(targetId.Guid.ToString("B").ToUpperInvariant());
@@ -1261,7 +1261,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
                 }
 
 
-#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/DataMappers/SitecoreInfoMapperFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/DataMappers/SitecoreInfoMapperFixture.cs
@@ -19,7 +19,7 @@ using Sitecore.FakeDb;
 using Sitecore.Resources.Media;
 using Sitecore.SecurityModel;
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 using Sitecore.Abstractions;
 using Sitecore.DependencyInjection;
 #endif
@@ -70,7 +70,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
             })
             {
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 
@@ -298,7 +298,7 @@ namespace Glass.Mapper.Sc.FakeDb.DataMappers
                 };
 
 
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/Glass.Mapper.Sc.FakeDb.csproj
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/Glass.Mapper.Sc.FakeDb.csproj
@@ -10,7 +10,8 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestorePackages>true</RestorePackages>
-   <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+   <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
+   <TargetFramework>net481</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -63,12 +64,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
 		<PackageReference Include="Sitecore.FakeDb" Version="$(ScFakeDBVersion)" />
 		<PackageReference Include="Sitecore.FakeDb.NSubstitute" Version="$(ScFakeDBVersion)" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Sitecore.Kernel" Version="$(ScVersion)" />
-		<PackageReference Include="Sitecore.Nexus" Version="$(ScVersion)" Condition="'$(ScVersion)' != '10.2.0' and '$(ScVersion)' != '10.3.0'" />
 		<PackageReference Include="Sitecore.Analytics" Version="$(ScVersion)" />
 		<PackageReference Include="Sitecore.Client" Version="$(ScVersion)" />
 	</ItemGroup>

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/GlassHtmlFixture.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/GlassHtmlFixture.cs
@@ -13,7 +13,7 @@ using Glass.Mapper.Sc.Configuration.Attributes;
 using Glass.Mapper.Sc.Fields;
 using NSubstitute;
 using NUnit.Framework;
-#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92  || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 using Sitecore.Abstractions;
     using Sitecore.DependencyInjection;
 #endif
@@ -28,7 +28,7 @@ using Sitecore.Web;
 using Site = System.Security.Policy.Site;
 
 
-#if SC100 || SC101 || SC102 || SC103
+#if SC100 || SC101 || SC102 || SC103 || SC104
 using Sitecore.Links.UrlBuilders;
 #endif
 
@@ -233,7 +233,7 @@ namespace Glass.Mapper.Sc.FakeDb
 
 
 
-#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 
@@ -342,7 +342,7 @@ namespace Glass.Mapper.Sc.FakeDb
                 var html = GetGlassHtml(service);
 
 
-#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 
@@ -442,7 +442,7 @@ namespace Glass.Mapper.Sc.FakeDb
                 var service = new SitecoreService(database.Database);
                 var html = GetGlassHtml(service);
 
-#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
 
                 var mediaUrlProvider = Substitute.For<BaseMediaManager>();
 
@@ -3206,7 +3206,7 @@ namespace Glass.Mapper.Sc.FakeDb
             Assert.AreEqual(expected, result);
         }
 
-#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
         [Test]
         public void RenderLink_BlankTarget_AddsNoOpener()
         {

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/Infrastructure/Pipelines/RenderField/RenderWebEdit.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/Infrastructure/Pipelines/RenderField/RenderWebEdit.cs
@@ -66,7 +66,7 @@ namespace Glass.Mapper.Sc.FakeDb.Infrastructure.Pipelines.RenderField
         private bool CanEditField(Field field)
         {
             Assert.ArgumentNotNull((object)field, "field");
-#if SC93 || SC100 || SC101 || SC102 || SC103
+#if SC93 || SC100 || SC101 || SC102 || SC103 || SC104
             return true;
 
 #else
@@ -103,7 +103,7 @@ namespace Glass.Mapper.Sc.FakeDb.Infrastructure.Pipelines.RenderField
 
             return site != null 
                 && site.DisplayMode == DisplayMode.Edit && (!(WebUtil.GetQueryString("sc_duration") == "temporary")
-#if SC82 || SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103
+#if SC82 || SC90 || SC91 || SC92 || SC93 || SC100 || SC101 || SC102 || SC103 || SC104
                 && Sitecore.Context.PageMode.IsExperienceEditorEditing);
 #else
                 && Sitecore.Context.PageMode.IsPageEditorEditing);
@@ -170,7 +170,7 @@ namespace Glass.Mapper.Sc.FakeDb.Infrastructure.Pipelines.RenderField
                 str =GetDefaultText(args);
             }
             this.AddParameters(fieldTag, args);
-#if !SC93 && !SC100 && !SC101 && !SC102 && !SC103
+#if !SC93 && !SC100 && !SC101 && !SC102 && !SC103 && !SC104
             if (args.FieldTypeKey.ToLowerInvariant() == "word document" && args.Parameters["editormode"] == "inline")
                 ApplyWordFieldStyle(fieldTag, args);
 #endif
@@ -267,7 +267,7 @@ namespace Glass.Mapper.Sc.FakeDb.Infrastructure.Pipelines.RenderField
             return args.FieldName;
         }
 
-#if !SC93 && !SC100 && !SC101 && !SC102 && !SC103 //removed in SC93 & SC100
+#if !SC93 && !SC100 && !SC101 && !SC102 && !SC103 && !SC104 //removed in SC93 & SC100
 
         /// <summary>Gets the word style string.</summary>
         /// <param name="tag">The tag.</param>

--- a/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/ScVersionTest.cs
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.FakeDb/ScVersionTest.cs
@@ -82,5 +82,11 @@ namespace Glass.Mapper.Sc.FakeDb
             Assert.True(true);
         }
 #endif
+#if SC103
+        public void Sc104()
+        {
+            Assert.True(true);
+        }
+#endif
     }
 }

--- a/Tests/Unit Tests/Glass.Mapper.Sc.Mvc.Tests/Glass.Mapper.Sc.Mvc.Tests.csproj
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.Mvc.Tests/Glass.Mapper.Sc.Mvc.Tests.csproj
@@ -10,7 +10,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
+    <TargetFramework>net481</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -56,7 +57,6 @@
 	<ItemGroup>
 		<PackageReference Include="Sitecore.Kernel" Version="$(ScVersion)" />
 		<PackageReference Include="Sitecore.Mvc" Version="$(ScVersion)" />
-		<PackageReference Include="Sitecore.Nexus" Version="$(ScVersion)" Condition="'$(ScVersion)' != '10.2.0' and '$(ScVersion)' != '10.3.0'" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(IncludeContentExtractionDll)' == 'true'">
 		<PackageReference Include="Sitecore.ContentSearch.ContentExtraction" Version="$(ScVersion)" />

--- a/Tests/Unit Tests/Glass.Mapper.Sc.V5.Tests/Glass.Mapper.Sc.V5.Tests.csproj
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.V5.Tests/Glass.Mapper.Sc.V5.Tests.csproj
@@ -10,7 +10,8 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestorePackages>true</RestorePackages>
-   <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+   <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
+   <TargetFramework>net481</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -56,7 +57,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Sitecore.Kernel" Version="$(ScVersion)" />
-		<PackageReference Include="Sitecore.Nexus" Version="$(ScVersion)" Condition="'$(ScVersion)' != '10.2.0' and '$(ScVersion)' != '10.3.0'" />
 		<PackageReference Include="Sitecore.Analytics" Version="$(ScVersion)" />
 		<PackageReference Include="Sitecore.Client" Version="$(ScVersion)" />
 	</ItemGroup>

--- a/Tests/Unit Tests/Glass.Mapper.Sc.WebForms.FakeDb/Glass.Mapper.Sc.WebForms.FakeDb.csproj
+++ b/Tests/Unit Tests/Glass.Mapper.Sc.WebForms.FakeDb/Glass.Mapper.Sc.WebForms.FakeDb.csproj
@@ -8,7 +8,8 @@
     <RootNamespace>Glass.Mapper.Sc.WebForms.FakeDb</RootNamespace>
     <AssemblyName>Glass.Mapper.Sc.WebForms.FakeDb</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
+    <TargetFramework>net481</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -19,7 +20,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -54,7 +55,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Sitecore.Kernel" Version="$(ScVersion)" />
-		<PackageReference Include="Sitecore.Nexus" Version="$(ScVersion)" Condition="'$(ScVersion)' != '10.2.0' and '$(ScVersion)' != '10.3.0'" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(IncludeContentExtractionDll)' == 'true'">
 		<PackageReference Include="Sitecore.ContentSearch.ContentExtraction" Version="$(ScVersion)" />

--- a/Tests/Unit Tests/Glass.Mapper.Tests/Glass.Mapper.Tests.csproj
+++ b/Tests/Unit Tests/Glass.Mapper.Tests/Glass.Mapper.Tests.csproj
@@ -12,8 +12,9 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103</Configurations>
+    <Configurations>Debug;Release;sc100;sc93;sc92;sc91;sc90;sc82;sc81;sc80;sc75;sc72;sc71;sc70;sc101;sc102;Sc103;Sc104</Configurations>
     <TargetFrameworkProfile />
+    <TargetFramework>net481</TargetFramework>
   </PropertyGroup>
 	<Import Project="$(SolutionDir)CommonSettings.targets" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -25,7 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc103|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sc104|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>


### PR DESCRIPTION
Upgraded all sitecore librray related to Sitecore 10.4 
and handled exception for below error -
Exception: System.NullReferenceException
Message: Object reference not set to an instance of an object. Source: Sitecore.Kernel
at Sitecore.Links.UrlBuilders.Helpers.ItemPathBuilder.GetRelativePath(Item item, SiteInfo site) at Sitecore.Links.UrlBuilders.Helpers.ItemPathBuilder.Build(Item item, SiteInfo site)